### PR TITLE
feat: add job management for subclient vmware

### DIFF
--- a/.changelog/21.txt
+++ b/.changelog/21.txt
@@ -1,0 +1,11 @@
+```release-note:feature
+`subclient/vmware` - Implemented job parsing and status handling for the VMware subclient, enabling support for asynchronous VMware operations.
+```
+
+```release-note:feature
+`client` - Extended the `Client` interface and subclient registry to support job-related methods and mock job clients.
+```
+
+```release-note:note
+Enhanced documentation for VMware subclient job methods and error handling.
+```

--- a/cav/client_option_test.go
+++ b/cav/client_option_test.go
@@ -12,9 +12,8 @@ package cav
 import (
 	"testing"
 
-	"resty.dev/v3"
-
 	"github.com/stretchr/testify/assert"
+	"resty.dev/v3"
 
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/auth"
 	subclient "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/subClient"
@@ -33,7 +32,7 @@ var getMockConsole = func() consoles.Console {
 func TestWithCloudAvenueCredential_SetsCredentials(t *testing.T) {
 	// Mock the NewCloudavenueCredential function to return a mock auth
 	origNewCloudavenueCredential := auth.NewCloudavenueCredential
-	auth.NewCloudavenueCredential = func(_ *resty.Client, _ consoles.Console, _ string, _ string, _ string) (auth.Auth, error) {
+	auth.NewCloudavenueCredential = func(_ *resty.Client, _ consoles.Console, _, _, _ string) (auth.Auth, error) {
 		return getMockAuth, nil
 	}
 	defer func() { auth.NewCloudavenueCredential = origNewCloudavenueCredential }()

--- a/cav/request_test.go
+++ b/cav/request_test.go
@@ -29,6 +29,7 @@ func Test_NewRequest_WithoutAuth(t *testing.T) {
 		t.Fatalf("Expected error message 'invalid client mock', got '%v'", err.Error())
 	}
 }
+
 func Test_NewRequest(t *testing.T) {
 	client, err := NewClient("mockorg001", WithMock())
 	if err != nil {
@@ -40,6 +41,7 @@ func Test_NewRequest(t *testing.T) {
 		t.Fatalf("Error creating request with mock: %v", err)
 	}
 }
+
 func Test_NewRequest_RequestOptionsError(t *testing.T) {
 	client, err := NewClient("mockorg001", WithMock())
 	if err != nil {

--- a/internal/auth/cloudavenue-credential.go
+++ b/internal/auth/cloudavenue-credential.go
@@ -88,7 +88,6 @@ func (c *CloudavenueCredential) Refresh(ctx context.Context) error {
 	}
 
 	resp, err := r.Post(c.console.GetAPIVCDEndpoint() + "/1.0.0/sessions")
-
 	if err != nil {
 		c.bearer = ""
 		return err

--- a/internal/auth/cloudavenue-credential_test.go
+++ b/internal/auth/cloudavenue-credential_test.go
@@ -15,9 +15,10 @@ import (
 	"testing"
 
 	"github.com/jarcoal/httpmock"
-	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/consoles"
 	"github.com/stretchr/testify/assert"
 	"resty.dev/v3"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/consoles"
 )
 
 var getMockConsole = func() consoles.Console {
@@ -193,6 +194,7 @@ func TestCloudavenueCredential_NewCloudavenueCredential_NilClient(t *testing.T) 
 	}
 	assert.Equal(t, "http client cannot be nil", err.Error())
 }
+
 func TestCloudavenueCredential_NewCloudavenueCredential_EmptyOrganization(t *testing.T) {
 	_, err := newCloudavenueCredential(getMockRestyClient(), getMockConsole(), "", "user", "pass")
 	if err == nil {
@@ -200,6 +202,7 @@ func TestCloudavenueCredential_NewCloudavenueCredential_EmptyOrganization(t *tes
 	}
 	assert.Equal(t, "organization cannot be empty", err.Error())
 }
+
 func TestCloudavenueCredential_NewCloudavenueCredential_EmptyUsername(t *testing.T) {
 	_, err := newCloudavenueCredential(getMockRestyClient(), getMockConsole(), "org", "", "pass")
 	if err == nil {
@@ -207,6 +210,7 @@ func TestCloudavenueCredential_NewCloudavenueCredential_EmptyUsername(t *testing
 	}
 	assert.Equal(t, "username cannot be empty", err.Error())
 }
+
 func TestCloudavenueCredential_NewCloudavenueCredential_EmptyPassword(t *testing.T) {
 	_, err := newCloudavenueCredential(getMockRestyClient(), getMockConsole(), "org", "user", "")
 	if err == nil {

--- a/internal/subClient/mock.go
+++ b/internal/subClient/mock.go
@@ -12,9 +12,8 @@ package subclient
 import (
 	"context"
 
-	"resty.dev/v3"
-
 	"github.com/jarcoal/httpmock"
+	"resty.dev/v3"
 
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/auth"
 	httpclient "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/httpClient"

--- a/internal/subClient/mock_test.go
+++ b/internal/subClient/mock_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/auth"
 	httpclient "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/httpClient"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/jobs"
 )
 
 func TestMock_NewHTTPClient_Success(t *testing.T) {
@@ -41,7 +42,7 @@ func TestMock_NewHTTPClient_Success(t *testing.T) {
 	})
 	assert.NotNil(t, cred)
 
-	vmw := &mockClient{}
+	vmw := &MockClient{}
 	vmw.SetConsole(getMockConsole())
 	vmw.SetCredential(cred)
 
@@ -52,20 +53,20 @@ func TestMock_NewHTTPClient_Success(t *testing.T) {
 }
 
 func TestMock_ParseAPIError_NilResponse(t *testing.T) {
-	vmw := &mockClient{}
+	vmw := &MockClient{}
 	err := vmw.ParseAPIError(nil)
 	assert.Nil(t, err)
 }
 
 func TestMock_ParseAPIError_NilError(t *testing.T) {
-	vmw := &mockClient{}
+	vmw := &MockClient{}
 	resp := &resty.Response{}
 	err := vmw.ParseAPIError(resp)
 	assert.Nil(t, err)
 }
 
 func TestMock_ParseAPIError_ErrorResponse(t *testing.T) {
-	vmw := &mockClient{}
+	vmw := &MockClient{}
 	resp := &resty.Response{
 		RawResponse: &http.Response{
 			StatusCode: 400,
@@ -91,7 +92,7 @@ func TestMock_ParseAPIError_ErrorResponse(t *testing.T) {
 }
 
 func TestMock_ParseAPIError_ErrorResponse_Unknown(t *testing.T) {
-	vmw := &mockClient{}
+	vmw := &MockClient{}
 	resp := &resty.Response{
 		RawResponse: &http.Response{
 			StatusCode: 500,
@@ -107,4 +108,116 @@ func TestMock_ParseAPIError_ErrorResponse_Unknown(t *testing.T) {
 
 	apiErr := vmw.ParseAPIError(resp)
 	assert.Nil(t, apiErr)
+}
+
+func TestMockJobClientWithJob_SetCredential_And_SetConsole(t *testing.T) {
+	mockJobClient := &MockJobClientWithJob{
+		Client: &MockClient{},
+	}
+	mockAuth := auth.NewMockAuth(map[string]string{"Test": "value"})
+	mockConsole := getMockConsole()
+
+	mockJobClient.SetCredential(mockAuth)
+	assert.Equal(t, mockAuth, mockJobClient.Client.(*MockClient).credential)
+
+	mockJobClient.SetConsole(mockConsole)
+	assert.Equal(t, mockConsole, mockJobClient.Client.(*MockClient).console)
+}
+
+func TestMockWithJob_NewHTTPClient_Success(t *testing.T) {
+	_ = httpclient.NewMockHTTPClient()
+	defer httpmock.DeactivateAndReset()
+
+	httpmock.RegisterResponder(
+		"POST",
+		"http://mock.api/cloudapi/1.0.0/sessions",
+		httpmock.NewStringResponder(200, "ok").
+			HeaderSet(map[string][]string{
+				auth.XVmwareAccessToken: {"token-vmware"},
+			}),
+	)
+
+	// Mock the NewCloudavenueCredential function to return a mock auth
+	cred := auth.NewMockAuth(map[string]string{
+		"Mock-Header": "mock-value",
+	})
+	assert.NotNil(t, cred)
+
+	vmw := NewMockJobClient()
+	vmw.SetConsole(getMockConsole())
+	vmw.SetCredential(cred)
+
+	httpC, err := vmw.NewHTTPClient(t.Context())
+	assert.NoError(t, err)
+	assert.NotNil(t, httpC)
+	assert.Equal(t, "mock-value", cred.Headers()["Mock-Header"])
+}
+
+func TestMockWithJob_ParseAPIError_NilResponse(t *testing.T) {
+	vmw := NewMockJobClient()
+	err := vmw.ParseAPIError(nil)
+	assert.Nil(t, err)
+}
+
+func TestMockWithJob_ParseAPIError_NilError(t *testing.T) {
+	vmw := NewMockJobClient()
+	resp := &resty.Response{}
+	err := vmw.ParseAPIError(resp)
+	assert.Nil(t, err)
+}
+
+func TestMockWithJob_ParseAPIError_ErrorResponse(t *testing.T) {
+	vmw := NewMockJobClient()
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: 400,
+			Status:     http.StatusText(400),
+			Body:       http.NoBody,
+		},
+		Body: http.NoBody,
+		Request: &resty.Request{
+			URL: "http://mock.api/mock",
+			Error: &MockError{
+				Message: "Bad Request",
+			},
+			Time: time.Now(),
+		},
+	}
+
+	apiErr := vmw.ParseAPIError(resp)
+	assert.NotNil(t, apiErr)
+	assert.Equal(t, 400, apiErr.StatusCode)
+	assert.Equal(t, "Bad Request", apiErr.Message)
+	assert.Equal(t, resp.Duration(), apiErr.Duration)
+	assert.Equal(t, resp.Request.URL, apiErr.Endpoint)
+}
+
+func TestMockWithJob_ParseAPIError_ErrorResponse_Unknown(t *testing.T) {
+	vmw := NewMockJobClient()
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: 500,
+			Status:     http.StatusText(500),
+			Body:       http.NoBody,
+		},
+		Body: http.NoBody,
+		Request: &resty.Request{
+			URL:   "http://mock.api/mock",
+			Error: "Internal Server Error",
+		},
+	}
+
+	apiErr := vmw.ParseAPIError(resp)
+	assert.Nil(t, apiErr)
+}
+
+func TestMockJobClientWithJob_JobRefresh_Success(t *testing.T) {
+	vmw := NewMockJobClient()
+
+	if vmwJob, ok := vmw.(jobs.Client); ok {
+		job, err := vmwJob.JobRefresh(nil, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, job)
+		// assert.Equal(t, "http://mock.api/job/123", job.HREF)
+	}
 }

--- a/internal/subClient/subclient.go
+++ b/internal/subClient/subclient.go
@@ -24,6 +24,8 @@ var Clients = map[Name]Client{
 	Cerberus: NewCerberusClient(),
 	// Mock client for testing purposes
 	mock: NewMockClient(),
+	// Mock job client for testing purposes
+	mockJob: NewMockJobClient(),
 }
 
 type Name string
@@ -32,7 +34,8 @@ const (
 	Vmware    Name = "vmware"
 	Cerberus  Name = "cerberus"
 	Netbackup Name = "netbackup"
-	mock      Name = "mock" // For testing purposes
+	mock      Name = "mock"     // For testing purposes
+	mockJob   Name = "mock-job" // For testing purposes with jobs
 )
 
 type client struct {
@@ -45,5 +48,9 @@ type Client interface {
 	SetCredential(auth.Auth)
 	SetConsole(consoles.Console)
 	NewHTTPClient(context.Context) (*resty.Client, error)
+
+	// TODO(azrod): Add field operation to ParseAPIError to force user to set the name of the operation
+	// E.g. ParseAPIError(*resty.Response, "CreateVM") *errors.APIError
+
 	ParseAPIError(*resty.Response) *errors.APIError
 }

--- a/internal/subClient/vmware.go
+++ b/internal/subClient/vmware.go
@@ -20,9 +20,7 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
 )
 
-var (
-	_ Client = &vmware{}
-)
+var _ Client = &vmware{}
 
 var NewVmwareClient = func() Client {
 	return &vmware{}

--- a/internal/subClient/vmware_jobs.go
+++ b/internal/subClient/vmware_jobs.go
@@ -51,7 +51,6 @@ func (v *vmware) JobRefresh(newReq *resty.Request, resp *resty.Response) (job *j
 		SetResult(VmwareJobAPIResponse{}).
 		SetError(VmwareError{}).
 		Get(job.HREF)
-
 	if err != nil {
 		return job, err
 	}

--- a/internal/subClient/vmware_jobs.go
+++ b/internal/subClient/vmware_jobs.go
@@ -1,0 +1,125 @@
+package subclient
+
+import (
+	"resty.dev/v3"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/auth"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/jobs"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
+)
+
+var _ jobs.Client = &vmware{}
+
+// VmwareJobAPIResponse represents an asynchronous operation in VMware Cloud Director.
+type VmwareJobAPIResponse struct {
+	HREF             string       `json:"href,omitempty"`             // The URI of the entity.
+	ID               string       `json:"id,omitempty"`               // The entity identifier, expressed in URN format. The value of this attribute uniquely identifies the entity, persists for the life of the entity, and is never reused.
+	OperationKey     string       `json:"operationKey,omitempty"`     // Optional unique identifier to support idempotent semantics for create and delete operations.
+	Name             string       `json:"name,omitempty"`             // The name of the entity.
+	Status           string       `json:"status,omitempty"`           // The execution status of the task. One of queued, preRunning, running, success, error, aborted
+	Operation        string       `json:"operation,omitempty"`        // A message describing the operation that is tracked by this task.
+	OperationName    string       `json:"operationName,omitempty"`    // The short name of the operation that is tracked by this task.
+	ServiceNamespace string       `json:"serviceNamespace,omitempty"` // Identifier of the service that created the task. It must not start with com.vmware.vcloud and the length must be between 1 and 128 symbols.
+	StartTime        string       `json:"startTime,omitempty"`        // The date and time the system started executing the task. May not be present if the task has not been executed yet.
+	EndTime          string       `json:"endTime,omitempty"`          // The date and time that processing of the task was completed. May not be present if the task is still being executed.
+	ExpiryTime       string       `json:"expiryTime,omitempty"`       // The date and time at which the task resource will be destroyed and no longer available for retrieval. May not be present if the task has not been executed or is still being executed.
+	CancelRequested  bool         `json:"cancelRequested,omitempty"`  // Whether user has requested this processing to be canceled.
+	Description      string       `json:"description,omitempty"`      // Optional description.
+	Error            *VmwareError `json:"error,omitempty"`            // Represents error information from a failed task.
+	Progress         int          `json:"progress,omitempty"`         // Read-only indicator of task progress as an approximate percentage between 0 and 100. Not available for all tasks.
+	Details          string       `json:"details,omitempty"`          // Detailed message about the task. Also contained by the Owner entity when task status is preRunning.
+}
+
+// JobRefresh is a function type that defines how to refresh a job status.
+func (v *vmware) JobRefresh(newReq *resty.Request, resp *resty.Response) (job *jobs.Job, err error) {
+	job, err = v.JobParser(resp)
+	if err != nil {
+		return job, err
+	}
+
+	respR, err := newReq.
+		SetHeader("Accept", "application/*+json;version="+auth.VDCVersion).
+		SetResult(VmwareJobAPIResponse{}).
+		SetError(VmwareError{}).
+		Get(job.HREF)
+
+	if err != nil {
+		return job, err
+	}
+
+	if respR.IsError() {
+		if apiErr := v.ParseAPIError(respR); apiErr != nil {
+			return nil, apiErr
+		}
+		return nil, respR.Err
+	}
+
+	return v.JobParser(respR)
+}
+
+// JobParser parses the job response body and extracts the job information.
+func (v *vmware) JobParser(resp *resty.Response) (job *jobs.Job, err error) {
+	if resp == nil {
+		return job, errors.New("no response to parse")
+	}
+
+	// If the response is not of type VmwareJobAPIResponse, find the HREF in the header
+	if href := resp.Header().Get("Location"); href != "" {
+		job = &jobs.Job{
+			HREF: href,
+		}
+		return job, nil
+	}
+
+	if apiR, ok := resp.Result().(*VmwareJobAPIResponse); ok && apiR.Status != "" {
+		job = &jobs.Job{
+			ID:          apiR.ID,
+			Name:        apiR.Name,
+			Description: apiR.Description,
+			HREF:        apiR.HREF,
+		}
+
+		status, err := v.JobStatusParser(apiR.Status)
+		if err != nil {
+			return job, errors.New("failed to parse vmware job status: " + err.Error())
+		}
+
+		job.Status = status
+
+		if apiR.Error != nil {
+			return job, &errors.APIError{
+				StatusCode:    apiR.Error.StatusCode,
+				StatusMessage: apiR.Error.StatusMessage,
+				Operation:     apiR.Operation,
+				Message:       apiR.Error.Message,
+				Duration:      resp.Duration(),
+				Endpoint:      apiR.HREF,
+			}
+		}
+
+		return job, nil
+	}
+
+	return job, errors.New("failed to parse vmware job response, expected VmwareJobAPIResponse type")
+}
+
+// Status returns the job status from the response body.
+func (v *vmware) JobStatusParser(status string) (s jobs.Status, err error) {
+	switch status {
+	case "queued":
+		s = jobs.Queued
+	case "preRunning":
+		s = jobs.Running // preRunning is considered as running
+	case "running":
+		s = jobs.Running
+	case "success":
+		s = jobs.Success
+	case "error":
+		s = jobs.Error
+	case "aborted":
+		s = jobs.Aborted
+	default:
+		return s, errors.New("unknown job status: " + status)
+	}
+	return s, nil
+}

--- a/internal/subClient/vmware_jobs.go
+++ b/internal/subClient/vmware_jobs.go
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
 package subclient
 
 import (

--- a/internal/subClient/vmware_jobs_test.go
+++ b/internal/subClient/vmware_jobs_test.go
@@ -1,0 +1,319 @@
+package subclient
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/stretchr/testify/assert"
+	"resty.dev/v3"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/auth"
+	httpclient "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/httpClient"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/jobs"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
+)
+
+type mockVmware struct{}
+
+func (v *mockVmware) JobParser(resp *resty.Response) (*jobs.Job, error) {
+	if resp == nil {
+		return nil, errors.New("no response to parse")
+	}
+	// Simule un parsing simple pour les tests
+	if resp.Request != nil && resp.Request.URL == "error" {
+		return nil, errors.New("parse error")
+	}
+	return &jobs.Job{
+		HREF:   "http://mock.api/job/123",
+		Status: jobs.Queued,
+	}, nil
+}
+func (v *mockVmware) JobStatusParser(status string) (jobs.Status, error) {
+	return jobs.Queued, nil
+}
+
+// Test pour JobRefresh : succès complet
+func TestVmware_JobRefresh_ResponseNil(t *testing.T) {
+	vmw := NewVmwareClient()
+	vmw.SetConsole(getMockConsole())
+
+	if vmwJob, ok := vmw.(jobs.Client); ok {
+		job, err := vmwJob.JobRefresh(nil, nil)
+		assert.Error(t, err)
+		assert.Nil(t, job)
+	}
+}
+
+func mustResponder(responder httpmock.Responder, _ error) httpmock.Responder {
+	return responder
+}
+
+// Test pour JobRefresh : tests table-driven
+func TestVmware_JobRefresh_TableDriven(t *testing.T) {
+	type fields struct {
+		jobResponders []httpmock.Responder
+	}
+	type args struct {
+		req  *resty.Request
+		resp *resty.Response
+	}
+	tests := []struct {
+		name           string
+		fields         fields
+		statusExpected jobs.Status
+		wantErr        bool
+		wantNilJob     bool
+		wantJobHref    string
+		wantParseErr   bool
+	}{
+		{
+			name: "success",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					mustResponder(httpmock.NewJsonResponder(200, VmwareJobAPIResponse{
+						ID:          "123",
+						Name:        "Test Job",
+						Description: "This is a test job",
+						HREF:        "http://mock.api/job/123",
+						Status:      "success",
+						Operation:   "test-operation",
+					})),
+				},
+			},
+			wantErr:        false,
+			wantNilJob:     false,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: jobs.Success,
+		},
+		{
+			name: "error",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					mustResponder(httpmock.NewJsonResponder(200, VmwareJobAPIResponse{
+						ID:          "123",
+						Name:        "Test Job",
+						Description: "This is a test job",
+						HREF:        "http://mock.api/job/123",
+						Status:      "error",
+						Operation:   "test-operation",
+						Error: &VmwareError{
+							StatusCode:    500,
+							StatusMessage: "Internal Server Error",
+							Message:       "An error occurred",
+						},
+					})),
+				},
+			},
+			wantErr:        true,
+			wantNilJob:     false,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: jobs.Error,
+		},
+		{
+			name: "bad-job",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					mustResponder(httpmock.NewJsonResponder(200, VmwareJobAPIResponse{
+						ID:          "123",
+						Name:        "Test Job",
+						Description: "This is a test job",
+						HREF:        "http://mock.api/job/123",
+						Status:      "unknown",
+						Operation:   "test-operation",
+					})),
+				},
+			},
+			wantErr:        true,
+			wantNilJob:     false,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: "",
+		},
+		{
+			name: "bad-jobformat",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					httpmock.NewStringResponder(200, "unknown response format"),
+				},
+			},
+			wantErr:        true,
+			wantNilJob:     true,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: "",
+		},
+		{
+			name: "error-500",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					httpmock.NewStringResponder(500, "Internal Server Error"),
+				},
+			},
+			wantErr:        true,
+			wantNilJob:     true,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: "",
+		},
+		{
+			name: "error-vmware",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					mustResponder(httpmock.NewJsonResponder(500, VmwareError{
+						StatusCode:    500,
+						StatusMessage: "Internal Server Error",
+						Message:       "An error occurred",
+					})),
+				},
+			},
+			wantErr:        true,
+			wantNilJob:     true,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: "",
+			wantParseErr:   true,
+		},
+		{
+			name: "status-preRunning",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+
+					mustResponder(httpmock.NewJsonResponder(200, VmwareJobAPIResponse{
+						ID:          "123",
+						Name:        "Test Job",
+						Description: "This is a test job",
+						HREF:        "http://mock.api/job/123",
+						Status:      "preRunning", // preRunning is considered as running
+						Operation:   "test-operation",
+					})),
+				},
+			},
+			wantErr:        false,
+			wantNilJob:     false,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: jobs.Running, // pre-running is considered as running
+		},
+		{
+			name: "status-queued",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+
+					mustResponder(httpmock.NewJsonResponder(200, VmwareJobAPIResponse{
+						ID:          "123",
+						Name:        "Test Job",
+						Description: "This is a test job",
+						HREF:        "http://mock.api/job/123",
+						Status:      "queued",
+						Operation:   "test-operation",
+					})),
+				},
+			},
+			wantErr:        false,
+			wantNilJob:     false,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: jobs.Queued,
+		},
+		{
+			name: "status-running",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					mustResponder(httpmock.NewJsonResponder(200, VmwareJobAPIResponse{
+						ID:          "123",
+						Name:        "Test Job",
+						Description: "This is a test job",
+						HREF:        "http://mock.api/job/123",
+						Status:      "running",
+						Operation:   "test-operation",
+					})),
+				},
+			},
+			wantErr:        false,
+			wantNilJob:     false,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: jobs.Running,
+		},
+		{
+			name: "status-aborted",
+			fields: fields{
+				jobResponders: []httpmock.Responder{
+					mustResponder(httpmock.NewJsonResponder(200, VmwareJobAPIResponse{
+						ID:          "123",
+						Name:        "Test Job",
+						Description: "This is a test job",
+						HREF:        "http://mock.api/job/123",
+						Status:      "aborted",
+						Operation:   "test-operation",
+					})),
+				},
+			},
+			wantErr:        false,
+			wantNilJob:     false,
+			wantJobHref:    "http://mock.api/job/123",
+			statusExpected: jobs.Aborted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock the NewCloudavenueCredential function to return a mock auth
+			cred := auth.NewMockAuth(map[string]string{
+				"Mock-Header": "mock-value",
+			})
+
+			// Setup
+			vmw := NewVmwareClient()
+			vmw.SetConsole(getMockConsole())
+			vmw.SetCredential(cred)
+
+			hC := httpclient.NewMockHTTPClient()
+			defer httpmock.DeactivateAndReset()
+			for _, responder := range tt.fields.jobResponders {
+				httpmock.RegisterResponder("GET", "http://mock.api/job/123", responder)
+			}
+
+			// Mock resty.Request et resty.Response
+			req := hC.R()
+			req.SetHeader("Accept", "application/json")
+			req.SetResult(VmwareJobAPIResponse{})
+			req.SetError(VmwareError{})
+			req.Result = &VmwareJobAPIResponse{
+				ID:          "123",
+				Name:        "Test Job",
+				Description: "This is a test job",
+				HREF:        "http://mock.api/job/123",
+				Status:      "queued",
+				Operation:   "test-operation",
+			}
+			req.URL = "http://mock.api/test"
+			req.SetContext(t.Context())
+			resp := &resty.Response{
+				Request: req,
+				RawResponse: &http.Response{
+					Header: map[string][]string{
+						"Location": {"http://mock.api/job/123"},
+					},
+				},
+			}
+
+			if vmwJob, ok := vmw.(jobs.Client); ok {
+				job, err := vmwJob.JobRefresh(req, resp)
+				if tt.wantNilJob {
+					assert.Nil(t, job)
+				} else {
+					assert.NotNil(t, job)
+					assert.Equal(t, "http://mock.api/job/123", job.HREF)
+					assert.Equal(t, tt.statusExpected, job.Status)
+				}
+				if tt.wantErr {
+					assert.Error(t, err)
+					if tt.wantParseErr {
+						if apiErr, ok := err.(*errors.APIError); ok {
+							assert.Equal(t, 500, apiErr.StatusCode)
+							assert.Equal(t, "Internal Server Error", apiErr.StatusMessage)
+							assert.Equal(t, "An error occurred", apiErr.Message)
+						}
+					}
+				} else {
+					assert.NoError(t, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/subClient/vmware_jobs_test.go
+++ b/internal/subClient/vmware_jobs_test.go
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
 package subclient
 
 import (

--- a/internal/subClient/vmware_test.go
+++ b/internal/subClient/vmware_test.go
@@ -106,9 +106,10 @@ func TestVmware_ParseAPIError_ErrorResponse(t *testing.T) {
 		Body: http.NoBody,
 		Request: &resty.Request{
 			URL: "http://mock.api/vmware",
-			Error: &vmwareError{
-				Message:        "Bad Request",
-				MinorErrorCode: "1234",
+			Error: &VmwareError{
+				Message:       "Bad Request",
+				StatusCode:    400,
+				StatusMessage: "1234",
 			},
 		},
 	}

--- a/internal/subClient/vmware_types.go
+++ b/internal/subClient/vmware_types.go
@@ -15,30 +15,12 @@ type vmware struct {
 	client
 }
 
-// vmwareError represents the error structure returned by VMware Cloud Director API.
+// VmwareError represents the error structure returned by VMware Cloud Director API.
 // It contains a message and a minor error code.
 // This structure is used to parse error responses from the VMware API.
-type vmwareError struct {
-	Message        string `json:"message"`
-	MinorErrorCode string `json:"minorErrorCode"`
-}
-
-// vmwareJobAPIResponse represents an asynchronous operation in VMware Cloud Director.
-type vmwareJobAPIResponse struct {
-	HREF             string       `json:"HREF,omitempty"`             // The URI of the entity.
-	ID               string       `json:"ID,omitempty"`               // The entity identifier, expressed in URN format. The value of this attribute uniquely identifies the entity, persists for the life of the entity, and is never reused.
-	OperationKey     string       `json:"operationKey,omitempty"`     // Optional unique identifier to support idempotent semantics for create and delete operations.
-	Name             string       `json:"name,omitempty"`             // The name of the entity.
-	Status           string       `json:"status,omitempty"`           // The execution status of the task. One of queued, preRunning, running, success, error, aborted
-	Operation        string       `json:"operation,omitempty"`        // A message describing the operation that is tracked by this task.
-	OperationName    string       `json:"operationName,omitempty"`    // The short name of the operation that is tracked by this task.
-	ServiceNamespace string       `json:"serviceNamespace,omitempty"` // Identifier of the service that created the task. It must not start with com.vmware.vcloud and the length must be between 1 and 128 symbols.
-	StartTime        string       `json:"startTime,omitempty"`        // The date and time the system started executing the task. May not be present if the task has not been executed yet.
-	EndTime          string       `json:"endTime,omitempty"`          // The date and time that processing of the task was completed. May not be present if the task is still being executed.
-	ExpiryTime       string       `json:"expiryTime,omitempty"`       // The date and time at which the task resource will be destroyed and no longer available for retrieval. May not be present if the task has not been executed or is still being executed.
-	CancelRequested  bool         `json:"cancelRequested,omitempty"`  // Whether user has requested this processing to be canceled.
-	Description      string       `json:"description,omitempty"`      // Optional description.
-	Error            *vmwareError `json:"error,omitempty"`            // Represents error information from a failed task.
-	Progress         int          `json:"progress,omitempty"`         // Read-only indicator of task progress as an approximate percentage between 0 and 100. Not available for all tasks.
-	Details          string       `json:"details,omitempty"`          // Detailed message about the task. Also contained by the Owner entity when task status is preRunning.
+type VmwareError struct {
+	// DOC API : https://developer.broadcom.com/xapis/vmware-cloud-director-api/38.1/doc/types/ErrorType.html
+	Message       string `json:"message"`
+	StatusCode    int    `json:"majorErrorCode"`
+	StatusMessage string `json:"minorErrorCode"`
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -30,4 +30,9 @@ func IsClientError(err error) bool {
 	return parseErrorType[*ClientError](err)
 }
 
-var New = errors.New
+// Reimplement golang errors function to avoid package name conflict
+var (
+	New = errors.New
+	As  = errors.As
+	Is  = errors.Is
+)


### PR DESCRIPTION
This pull request introduces significant enhancements to the mocking framework and job handling functionality for the Cloudavenue SDK. The changes include refactoring the mock client structure, adding support for job-related operations, and extending the VMware subclient to handle asynchronous job responses. Additionally, new tests have been added to validate the introduced functionality.

### Mock Client Refactoring and Enhancements:
* Renamed `mockClient` to `MockClient` and updated all associated methods to use the new struct. This improves clarity and aligns with Go naming conventions for exported types (`internal/subClient/mock.go`). [[1]](diffhunk://#diff-811deb0b641ed5becc9cbae823fa0cd7d80560cbcea73fc604341d48016d1e3dR21-R31) [[2]](diffhunk://#diff-811deb0b641ed5becc9cbae823fa0cd7d80560cbcea73fc604341d48016d1e3dL36-R43) [[3]](diffhunk://#diff-811deb0b641ed5becc9cbae823fa0cd7d80560cbcea73fc604341d48016d1e3dL50-R62) [[4]](diffhunk://#diff-811deb0b641ed5becc9cbae823fa0cd7d80560cbcea73fc604341d48016d1e3dR79-R129)
* Introduced `MockJobClientWithJob`, a new mock client for simulating job-related operations, including methods for parsing and refreshing job statuses (`internal/subClient/mock.go`).

### VMware Subclient Job Handling:
* Added a new file `vmware_jobs.go` to implement job-related operations for the VMware subclient, including job parsing, job status handling, and error handling for asynchronous operations (`internal/subClient/vmware_jobs.go`).
* Extended the `vmware` client to include job-related methods such as `JobRefresh` and `JobParser` for handling VMware job API responses (`internal/subClient/vmware_jobs.go`).

### Updates to Client Interface and Subclient Registry:
* Updated the `Client` interface to include job-related methods, paving the way for consistent job handling across clients (`internal/subClient/subclient.go`).
* Added `mockJob` to the subclient registry for testing job-related functionality (`internal/subClient/subclient.go`). [[1]](diffhunk://#diff-faf2d2f2b19520b5f5b9632bde862a01bd650d5638eddf306abda59f327700f5R27-R28) [[2]](diffhunk://#diff-faf2d2f2b19520b5f5b9632bde862a01bd650d5638eddf306abda59f327700f5R38)

### Test Suite Enhancements:
* Added comprehensive test cases for `MockJobClientWithJob` to validate credential setting, console setting, HTTP client creation, API error parsing, and job refresh functionality (`internal/subClient/mock_test.go`).
* Updated existing tests to reflect the renaming of `mockClient` to `MockClient` (`internal/subClient/mock_test.go`). [[1]](diffhunk://#diff-4f60093dba64b228b643ab66fdf7730cca0ec179e6d8ced6f87b7c5fe712874bL44-R45) [[2]](diffhunk://#diff-4f60093dba64b228b643ab66fdf7730cca0ec179e6d8ced6f87b7c5fe712874bL55-R69) [[3]](diffhunk://#diff-4f60093dba64b228b643ab66fdf7730cca0ec179e6d8ced6f87b7c5fe712874bL94-R95)

### Minor Changes and Documentation:
* Improved documentation for the VMware subclient, including comments on job-related methods and error handling (`internal/subClient/vmware.go`). [[1]](diffhunk://#diff-348ec90149cdac11b5ce507bc25d1d0f00bde2347e326b51a27fa16498555ffaL23-R45) [[2]](diffhunk://#diff-348ec90149cdac11b5ce507bc25d1d0f00bde2347e326b51a27fa16498555ffaR64-R73)