### PR TITLE
chore: improve endpoints storage and get

### DIFF
--- a/api/org/v1/org.go
+++ b/api/org/v1/org.go
@@ -19,9 +19,7 @@ import (
 
 func init() {
 	cav.Endpoint{
-		Category:     "demo",
-		Version:      cav.VersionV1,
-		Name:         "demo-api",
+		Name:         "GetOrganization",
 		Method:       cav.MethodGET,
 		SubClient:    cav.ClientVmware,
 		PathTemplate: "/1.0.0/orgs/{orgUrn}",
@@ -63,7 +61,7 @@ type OrgResponse struct { //nolint:revive
 
 // DemoRequest represents a request to the demo cav.
 func (o *Org) DemoRequest(ctx context.Context, orgID string) (*OrgResponse, error) {
-	demoEndpoint, err := cav.GetEndpoint("demo", cav.VersionV1, "demo-api", cav.MethodGET)
+	demoEndpoint, err := cav.GetEndpoint("GetOrganization", cav.MethodGET)
 	if err != nil {
 		return nil, err
 	}

--- a/api/org/v1/org_test.go
+++ b/api/org/v1/org_test.go
@@ -26,7 +26,7 @@ func TestDemoRequest(t *testing.T) {
 	oC, err := New(mC)
 	assert.Nil(t, err, "Error creating org client")
 
-	ep, err := mock.GetEndpoint("demo", cav.VersionV1, "demo-api", cav.MethodGET)
+	ep, err := mock.GetEndpoint("GetOrganization", cav.MethodGET)
 	if err != nil {
 		t.Fatalf("Error getting endpoint: %v", err)
 	}

--- a/cav/auth_cloudavenue_credential.go
+++ b/cav/auth_cloudavenue_credential.go
@@ -81,7 +81,7 @@ func (c *cloudavenueCredential) Headers() map[string]string {
 
 // Refresh is a placeholder method for refreshing the authentication token.
 func (c *cloudavenueCredential) Refresh(ctx context.Context) error {
-	ep, err := GetEndpoint(CategoryAuthentication, VersionV1, "CreateSessionVmware", MethodPOST)
+	ep, err := GetEndpoint("CreateSessionVmware", MethodPOST)
 	if err != nil {
 		return errors.New("failed to get endpoint for CreateSessionVmware: " + err.Error())
 	}

--- a/cav/auth_cloudavenue_credential_endpoint.go
+++ b/cav/auth_cloudavenue_credential_endpoint.go
@@ -17,8 +17,6 @@ import (
 
 func init() {
 	Endpoint{
-		Category:         CategoryAuthentication,
-		Version:          VersionV1,
 		Name:             "CreateSessionVmware",
 		Method:           MethodPOST,
 		SubClient:        ClientVmware,
@@ -30,7 +28,7 @@ func init() {
 		requestInternalFunc: func(ctx context.Context, client *resty.Client, endpoint *Endpoint, opts ...RequestOption) (*resty.Response, error) {
 			r := client.R().
 				SetContext(ctx).
-				SetHeader("Accept", "application/json;version="+vmwareVCDVersion)
+				SetHeader("Accept", "application/json;version="+vmwareVCDversion)
 
 			for _, opt := range opts {
 				if err := opt(endpoint, r); err != nil {

--- a/cav/endpoint_options.go
+++ b/cav/endpoint_options.go
@@ -20,17 +20,17 @@ import (
 func WithPathParam(pp PathParam, value string) RequestOption {
 	return func(endpoint *Endpoint, req *resty.Request) error {
 		if endpoint.PathParams == nil {
-			return errors.Newf("endpoint %s %s %s %s has no path params", endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method)
+			return errors.Newf("endpoint %s %s %s %s has no path params", endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
 		}
 
 		for _, p := range endpoint.PathParams {
 			if p.Name == pp.Name {
 				if p.Required && value == "" {
-					return errors.Newf("path param %s is required for endpoint %s %s %s %s", pp.Name, endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method)
+					return errors.Newf("path param %s is required for endpoint %s %s %s %s", pp.Name, endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
 				}
 				if p.ValidatorFunc != nil && value != "" {
 					if err := p.ValidatorFunc(value); err != nil {
-						return errors.Newf("path param %s validation failed for endpoint %s %s %s %s: %v", pp.Name, endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method, err)
+						return errors.Newf("path param %s validation failed for endpoint %s %s %s %s: %v", pp.Name, endpoint.api, endpoint.version, endpoint.Name, endpoint.Method, err)
 					}
 				}
 			}
@@ -44,17 +44,17 @@ func WithPathParam(pp PathParam, value string) RequestOption {
 func WithQueryParam(qp QueryParam, value string) RequestOption {
 	return func(endpoint *Endpoint, req *resty.Request) error {
 		if endpoint.QueryParams == nil {
-			return errors.Newf("endpoint %s %s %s %s has no query params", endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method)
+			return errors.Newf("endpoint %s %s %s %s has no query params", endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
 		}
 
 		for _, p := range endpoint.QueryParams {
 			if p.Name == qp.Name {
 				if p.Required && value == "" {
-					return errors.Newf("query param %s is required for endpoint %s %s %s %s", qp.Name, endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method)
+					return errors.Newf("query param %s is required for endpoint %s %s %s %s", qp.Name, endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
 				}
 				if p.ValidatorFunc != nil && value != "" {
 					if err := p.ValidatorFunc(value); err != nil {
-						return errors.Newf("query param %s validation failed for endpoint %s %s %s %s: %v", qp.Name, endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method, err)
+						return errors.Newf("query param %s validation failed for endpoint %s %s %s %s: %v", qp.Name, endpoint.api, endpoint.version, endpoint.Name, endpoint.Method, err)
 					}
 				}
 			}
@@ -68,7 +68,7 @@ func WithQueryParam(qp QueryParam, value string) RequestOption {
 func OverrideSetResult(rt any) RequestOption {
 	return func(endpoint *Endpoint, req *resty.Request) error {
 		if rt == nil {
-			return errors.Newf("result type cannot be nil for endpoint %s %s %s %s", endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method)
+			return errors.Newf("result type cannot be nil for endpoint %s %s %s %s", endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
 		}
 		req.SetResult(rt)
 		return nil
@@ -78,7 +78,7 @@ func OverrideSetResult(rt any) RequestOption {
 func SetBody(body any) RequestOption {
 	return func(endpoint *Endpoint, req *resty.Request) error {
 		if body == nil {
-			return errors.Newf("body cannot be nil for endpoint %s %s %s %s", endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method)
+			return errors.Newf("body cannot be nil for endpoint %s %s %s %s", endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
 		}
 
 		// Reflect BodyRequestType and body to ensure they match
@@ -86,7 +86,7 @@ func SetBody(body any) RequestOption {
 			reflectBodyType := reflect.TypeOf(endpoint.BodyRequestType)
 			reflectBody := reflect.TypeOf(body)
 			if reflectBody != reflectBodyType {
-				return errors.Newf("body must be of type %s for endpoint %s %s %s %s", reflectBodyType, endpoint.Category, endpoint.Version, endpoint.Name, endpoint.Method)
+				return errors.Newf("body must be of type %s for endpoint %s %s %s %s", reflectBodyType, endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
 			}
 		}
 

--- a/cav/endpoint_options_test.go
+++ b/cav/endpoint_options_test.go
@@ -23,7 +23,7 @@ type dummyBody struct {
 
 func TestSetBody_NilBody(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "POST",
+		api: "cat", version: "v1", Name: "name", Method: "POST",
 		BodyRequestType: dummyBody{},
 	}
 	req := resty.New().R()
@@ -36,7 +36,7 @@ func TestSetBody_NilBody(t *testing.T) {
 
 func TestSetBody_BodyRequestTypeMismatch(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "POST",
+		api: "cat", version: "v1", Name: "name", Method: "POST",
 		BodyRequestType: dummyBody{},
 	}
 	req := resty.New().R()
@@ -49,7 +49,7 @@ func TestSetBody_BodyRequestTypeMismatch(t *testing.T) {
 
 func TestSetBody_BodyRequestTypeMatch(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "POST",
+		api: "cat", version: "v1", Name: "name", Method: "POST",
 		BodyRequestType: dummyBody{},
 	}
 	req := resty.New().R()
@@ -66,7 +66,7 @@ func TestSetBody_BodyRequestTypeMatch(t *testing.T) {
 
 func TestSetBody_NoBodyRequestType(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "POST",
+		api: "cat", version: "v1", Name: "name", Method: "POST",
 		BodyRequestType: nil,
 	}
 	req := resty.New().R()
@@ -83,7 +83,7 @@ func TestSetBody_NoBodyRequestType(t *testing.T) {
 
 func TestWithQueryParam_NoQueryParams(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		QueryParams: nil,
 	}
 	req := resty.New().R()
@@ -97,7 +97,7 @@ func TestWithQueryParam_NoQueryParams(t *testing.T) {
 
 func TestWithQueryParam_RequiredMissing(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		QueryParams: []QueryParam{{Name: "foo", Required: true}},
 	}
 	req := resty.New().R()
@@ -114,7 +114,7 @@ func TestWithQueryParam_ValidatorFails(t *testing.T) {
 		return errors.Newf("invalid value")
 	}
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		QueryParams: []QueryParam{{Name: "foo", ValidatorFunc: validator}},
 	}
 	req := resty.New().R()
@@ -128,7 +128,7 @@ func TestWithQueryParam_ValidatorFails(t *testing.T) {
 
 func TestWithQueryParam_Success(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		QueryParams: []QueryParam{{Name: "foo"}},
 	}
 	req := resty.New().R()
@@ -145,7 +145,7 @@ func TestWithQueryParam_Success(t *testing.T) {
 
 func TestOverrideSetResult_NilResult(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 	}
 	req := resty.New().R()
 	opt := OverrideSetResult(nil)
@@ -157,7 +157,7 @@ func TestOverrideSetResult_NilResult(t *testing.T) {
 
 func TestOverrideSetResult_Success(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 	}
 	req := resty.New().R()
 	result := struct{ Foo string }{}
@@ -171,7 +171,7 @@ func TestOverrideSetResult_Success(t *testing.T) {
 
 func TestWithPathParam_NoPathParams(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		PathParams: nil,
 	}
 	req := resty.New().R()
@@ -185,7 +185,7 @@ func TestWithPathParam_NoPathParams(t *testing.T) {
 
 func TestWithPathParam_RequiredMissing(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		PathParams: []PathParam{{Name: "foo", Required: true}},
 	}
 	req := resty.New().R()
@@ -202,7 +202,7 @@ func TestWithPathParam_ValidatorFails(t *testing.T) {
 		return errors.Newf("invalid value")
 	}
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		PathParams: []PathParam{{Name: "foo", ValidatorFunc: validator}},
 	}
 	req := resty.New().R()
@@ -216,7 +216,7 @@ func TestWithPathParam_ValidatorFails(t *testing.T) {
 
 func TestWithPathParam_Success(t *testing.T) {
 	endpoint := &Endpoint{
-		Category: "cat", Version: "v1", Name: "name", Method: "GET",
+		api: "cat", version: "v1", Name: "name", Method: "GET",
 		PathParams: []PathParam{{Name: "foo"}},
 	}
 	req := resty.New().R()

--- a/cav/endpoint_registry.go
+++ b/cav/endpoint_registry.go
@@ -22,6 +22,9 @@ import (
 )
 
 const (
+	// API is the type for API names. (Type available in endpoint.go)
+	// Version is the type for API versions. (Type available in endpoint.go)
+
 	// * Exported api
 	// APIVDC         API = "vdc"
 	// APIEdgeGateway API = "edgegateway"

--- a/cav/endpoint_registry.go
+++ b/cav/endpoint_registry.go
@@ -8,3 +8,167 @@
  */
 
 package cav
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"runtime"
+	"strings"
+	"sync"
+
+	"github.com/orange-cloudavenue/common-go/validators"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
+)
+
+const (
+	// * Exported api
+	// APIVDC         API = "vdc"
+	// APIEdgeGateway API = "edgegateway"
+	// APIVApp        API = "vapp"
+	APIOrg API = "org"
+
+	// * Unexported api
+	// These are endpoints that are not meant to be used directly by the user.
+	apiCore API = "cav"
+
+	// * versions
+	VersionV1 Version = "v1"
+	VersionV2 Version = "v2"
+
+	// * Methods
+	MethodGET    Method = "GET"
+	MethodPOST   Method = "POST"
+	MethodPUT    Method = "PUT"
+	MethodDELETE Method = "DELETE"
+	MethodPATCH  Method = "PATCH"
+)
+
+type (
+	endpointsMap struct {
+		mu sync.RWMutex
+		// Map is a nested map structure to hold endpoints. String keys is a sha256 encoded string of the API/Version/Name/Method.
+		Map map[string]*Endpoint
+	}
+)
+
+var endpoints = endpointsMap{
+	Map: make(map[string]*Endpoint),
+}
+
+// Register registers an endpoint in the Endpoints map.
+func (e Endpoint) Register() {
+	if err := validators.New().Struct(&e); err != nil {
+		panic(err)
+	}
+
+	pc, _, _, ok := runtime.Caller(1)
+	if ok {
+		e.api, e.version = decodeCallerPackageName(runtime.FuncForPC(pc).Name())
+	}
+
+	if e.api == "" || e.version == "" {
+		panic("unable to determine API and version from caller context.")
+	}
+
+	// Set the endpoint in the Endpoints map
+	endpoints.register(&e)
+}
+
+// register is a helper function to register an endpoint with the given parameters.
+func (e *endpointsMap) register(endpoint *Endpoint) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if err := validators.New().Struct(endpoint); err != nil {
+		panic(err)
+	}
+
+	if endpoint.RequestFunc == nil {
+		// Default RequestFunc if not provided
+		endpoint.RequestFunc = DefaultRequestFunc
+	}
+
+	// Encode the endpoint to create a unique key
+	encodedKey := encodeEndpoint(endpoint.api, endpoint.version, endpoint.Name, endpoint.Method)
+
+	e.Map[encodedKey] = endpoint
+}
+
+// encode encodes the API, version, name, and method into a sha256 string.
+// This is used to create a unique identifier for the endpoint.
+func encodeEndpoint(api API, version Version, name string, method Method) string {
+	delimiter := "/"
+	s := string(api) + delimiter + string(version) + delimiter + name + delimiter + string(method)
+
+	h := sha256.New()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// GetEndpointsUncategorized retrieves all endpoints without categorization.
+func GetEndpointsUncategorized() []*Endpoint {
+	endpoints.mu.RLock()
+	defer endpoints.mu.RUnlock()
+
+	var endpointsList []*Endpoint
+
+	// Iterate through the endpoints map and collect all endpoints
+	for _, endpoint := range endpoints.Map {
+		endpointsList = append(endpointsList, endpoint)
+	}
+
+	return endpointsList
+}
+
+// GetEndpoint retrieves an endpoint from the Endpoints map based on the provided api, version, name, and method.
+func GetEndpoint(name string, method Method, opts ...EndpointRegistryOptions) (*Endpoint, error) {
+	endpoints.mu.RLock()
+	defer endpoints.mu.RUnlock()
+
+	var extraData = endpointRegistryOptions{}
+
+	for _, opt := range opts {
+		opt(&extraData)
+	}
+
+	if extraData.api == "" || extraData.version == "" {
+		pc, _, _, ok := runtime.Caller(1)
+		if ok {
+			extraData.api, extraData.version = decodeCallerPackageName(runtime.FuncForPC(pc).Name())
+		}
+		if extraData.api == "" || extraData.version == "" {
+			return nil, errors.New("unable to determine API and version from caller context. Use WithExtraProperties() to specify them explicitly.")
+		}
+	}
+
+	encodedKey := encodeEndpoint(extraData.api, extraData.version, name, method)
+	if endpoint, ok := endpoints.Map[encodedKey]; ok {
+		return endpoint, nil
+	}
+
+	return nil, errors.Newf("method %s not found for name %s in version %s of api %s", method, name, extraData.version, extraData.api)
+}
+
+func decodeCallerPackageName(funcName string) (API, Version) {
+	// funcName == github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/api/vdc/v1.funcName
+
+	// Remove prefix  (Result: /api/vdc/v1.funcName)
+	pkg := strings.TrimPrefix(funcName, "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/")
+
+	// Remove funcName from /api/vdc/v1.funcName (Result: /api/vdc/v1)
+	pkg = strings.Split(pkg, ".")[0]
+
+	switch {
+	case strings.HasPrefix(pkg, "api/"):
+		x := strings.SplitN(pkg, "/", 3)
+		if len(x) == 3 {
+			return API(x[1]), Version(x[2])
+		}
+	case strings.HasPrefix(pkg, "cav"):
+		// If the package is "cav", we assume it's a core endpoint
+		return API("cav"), VersionV1
+	}
+
+	return "", ""
+}

--- a/cav/endpoint_registry_options.go
+++ b/cav/endpoint_registry_options.go
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
 package cav
 
 type (

--- a/cav/endpoint_registry_options.go
+++ b/cav/endpoint_registry_options.go
@@ -1,0 +1,20 @@
+package cav
+
+type (
+	endpointRegistryOptions struct {
+		// API is the API name.
+		api API
+		// Version is the API version.
+		version Version
+	}
+
+	EndpointRegistryOptions func(*endpointRegistryOptions)
+)
+
+// WithExtraProperties allows adding extra properties to the endpoint registry options.
+func WithExtraProperties(api API, version Version) EndpointRegistryOptions {
+	return func(opts *endpointRegistryOptions) {
+		opts.api = api
+		opts.version = version
+	}
+}

--- a/cav/endpoint_registry_options_test.go
+++ b/cav/endpoint_registry_options_test.go
@@ -1,0 +1,23 @@
+package cav
+
+import (
+	"testing"
+)
+
+type mockAPI struct{}
+type mockVersion struct{}
+
+func TestWithExtraProperties(t *testing.T) {
+	var (
+		api  = API("mock")
+		opts endpointRegistryOptions
+	)
+	optFunc := WithExtraProperties(api, VersionV1)
+	optFunc(&opts)
+	if opts.api != api {
+		t.Errorf("expected api to be set")
+	}
+	if opts.version != VersionV1 {
+		t.Errorf("expected version to be set")
+	}
+}

--- a/cav/endpoint_registry_options_test.go
+++ b/cav/endpoint_registry_options_test.go
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
 package cav
 
 import (

--- a/cav/endpoint_stringer.go
+++ b/cav/endpoint_stringer.go
@@ -13,19 +13,19 @@ import "fmt"
 
 func (e Endpoint) String() string {
 	return fmt.Sprintf("[%s] %s %s %s %s",
-		e.Category,
-		e.Version,
+		e.api,
+		e.version,
 		e.Name,
 		e.Method,
 		e.PathTemplate)
 }
 
 // String returns a string representation of the Endpoint.
-func (e Category) String() string {
+func (e API) String() string {
 	return string(e)
 }
 
-// String returns a string representation of the Version.
+// String returns a string representation of the version.
 func (e Version) String() string {
 	return string(e)
 }

--- a/cav/endpoint_stringer_test.go
+++ b/cav/endpoint_stringer_test.go
@@ -15,8 +15,8 @@ import (
 
 func TestEndpoint_String(t *testing.T) {
 	e := Endpoint{
-		Category:     "cat",
-		Version:      "v1",
+		api:          "cat",
+		version:      "v1",
 		Name:         "endpointName",
 		Method:       "GET",
 		PathTemplate: "/path/{id}",

--- a/cav/endpoint_test.go
+++ b/cav/endpoint_test.go
@@ -20,8 +20,8 @@ func Test_Endpoint_Register(t *testing.T) {
 	}{
 		{
 			Endpoint: Endpoint{
-				Category:         Category("fake"),
-				Version:          VersionV1,
+				api:              API("fake"),
+				version:          VersionV1,
 				Name:             "fake",
 				Method:           MethodPOST,
 				SubClient:        ClientVmware,
@@ -35,7 +35,7 @@ func Test_Endpoint_Register(t *testing.T) {
 		},
 		{
 			Endpoint: Endpoint{
-				Category: "", // Invalid category
+				api: "", // Invalid api
 			},
 			expectedError: true,
 		},

--- a/cav/subclient_cerberus.go
+++ b/cav/subclient_cerberus.go
@@ -36,13 +36,13 @@ var newCerberusClient = func() SubClient {
 	return &cerberus{}
 }
 
-const cerberusVCDVersion = vmwareVCDVersion // Reusing the same version as VMware
+const cerberusVCDversion = vmwareVCDversion // Reusing the same version as VMware
 
 // NewClient creates a new request for the Cerberus subclient.
 func (v *cerberus) NewHTTPClient(ctx context.Context) (*resty.Client, error) {
 	v.httpClient = httpclient.NewHTTPClient().
 		SetBaseURL(v.console.GetAPICerberusEndpoint()).
-		SetHeader("Accept", "application/json;version="+cerberusVCDVersion).
+		SetHeader("Accept", "application/json;version="+cerberusVCDversion).
 		SetError(cerberusError{})
 
 	if !v.credential.IsInitialized() {

--- a/cav/subclient_cerberus_test.go
+++ b/cav/subclient_cerberus_test.go
@@ -20,7 +20,7 @@ func Test_NewRequest_Cerberus(t *testing.T) {
 	client, err := newMockClient()
 	assert.Nil(t, err, "Error creating mock client")
 
-	endpointSessionCerberus, err := GetEndpoint(CategoryAuthentication, VersionV1, "CreateSessionVmware", MethodPOST)
+	endpointSessionCerberus, err := GetEndpoint("CreateSessionVmware", MethodPOST)
 	assert.Nil(t, err, "Error getting endpoint for CreateSessionVmware")
 	defer endpointSessionCerberus.CleanMockResponse()
 

--- a/cav/subclient_vmware.go
+++ b/cav/subclient_vmware.go
@@ -32,7 +32,7 @@ type (
 	}
 )
 
-const vmwareVCDVersion = "38.1"
+const vmwareVCDversion = "38.1"
 
 var newVmwareClient = func() SubClient {
 	return &vmware{}
@@ -42,7 +42,7 @@ var newVmwareClient = func() SubClient {
 func (v *vmware) NewHTTPClient(ctx context.Context) (*resty.Client, error) {
 	v.httpClient = httpclient.NewHTTPClient().
 		SetBaseURL(v.console.GetAPIVCDEndpoint()).
-		SetHeader("Accept", "application/json;version="+vmwareVCDVersion).
+		SetHeader("Accept", "application/json;version="+vmwareVCDversion).
 		SetError(vmwareError{})
 
 	if !v.credential.IsInitialized() {

--- a/cav/subclient_vmware_test.go
+++ b/cav/subclient_vmware_test.go
@@ -20,7 +20,7 @@ func Test_NewRequest_Vmware(t *testing.T) {
 	client, err := newMockClient()
 	assert.Nil(t, err, "Error creating mock client")
 
-	endpointSessionVmware, err := GetEndpoint(CategoryAuthentication, VersionV1, "CreateSessionVmware", MethodPOST)
+	endpointSessionVmware, err := GetEndpoint("CreateSessionVmware", MethodPOST)
 	assert.Nil(t, err, "Error getting endpoint for CreateSessionVmware")
 	defer endpointSessionVmware.CleanMockResponse()
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.4
 require (
 	github.com/go-chi/chi/v5 v5.2.2
 	github.com/go-faker/faker/v4 v4.6.1
-	github.com/jarcoal/httpmock v1.4.0
 	github.com/orange-cloudavenue/common-go/validators v0.2.2
 	github.com/stretchr/testify v1.10.0
 	resty.dev/v3 v3.0.0-beta.3

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,6 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE=
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
-github.com/jarcoal/httpmock v1.4.0 h1:BvhqnH0JAYbNudL2GMJKgOHe2CtKlzJ/5rWKyp+hc2k=
-github.com/jarcoal/httpmock v1.4.0/go.mod h1:ftW1xULwo+j0R0JJkJIIi7UKigZUXCLLanykgjwBXL0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
@@ -131,8 +129,6 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/maxatome/go-testdeep v1.14.0 h1:rRlLv1+kI8eOI3OaBXZwb3O7xY3exRzdW5QyX48g9wI=
-github.com/maxatome/go-testdeep v1.14.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=


### PR DESCRIPTION
This pull request refactors the endpoint management system in the SDK to simplify the codebase by removing the `Category` and `Version` fields from the `Endpoint` struct and replacing them with `api` and `version`. It also removes category-based endpoint registration and retrieval methods, streamlining endpoint handling. Additionally, the changes update related test cases and error messages accordingly.

### Refactoring endpoint structure:

* [`cav/endpoint.go`](diffhunk://#diff-e4bf7e8aa1fa3f9decec7af9042f5228b41e79c8fcf2ea9c25987e6a86bcf981L14-R29): Removed the `Category` and `Version` fields from the `Endpoint` struct and replaced them with `api` and `version`. Simplified endpoint initialization by removing category-based methods and the `Register` function. [[1]](diffhunk://#diff-e4bf7e8aa1fa3f9decec7af9042f5228b41e79c8fcf2ea9c25987e6a86bcf981L14-R29) [[2]](diffhunk://#diff-e4bf7e8aa1fa3f9decec7af9042f5228b41e79c8fcf2ea9c25987e6a86bcf981L122-L292)

### Updates to endpoint-related functionality:

* [`api/org/v1/org.go`](diffhunk://#diff-2478ec4a8e283a21568a7f29e559fee2f7820f31eb55062b75c87dc64378d291L22-R22): Updated endpoint references to use the new `api` and `version` fields instead of `Category` and `Version`. [[1]](diffhunk://#diff-2478ec4a8e283a21568a7f29e559fee2f7820f31eb55062b75c87dc64378d291L22-R22) [[2]](diffhunk://#diff-2478ec4a8e283a21568a7f29e559fee2f7820f31eb55062b75c87dc64378d291L66-R64)
* `cav/auth_cloudavenue_credential.go` and `cav/auth_cloudavenue_credential_endpoint.go`: Adjusted endpoint initialization and retrieval logic to align with the new structure. [[1]](diffhunk://#diff-15dad32600d1b241ee36ee9476e94a06a8b4b486d65686642eead40cc4868637L84-R84) [[2]](diffhunk://#diff-692ff1b5b8b9db5e86bf3305f0df9ad51b9764784e3add2ca1be7b545fc8bff3L20-L21)

### Error message adjustments:

* [`cav/endpoint_options.go`](diffhunk://#diff-ab12a9e962ff1a451856f9c7105c30fb80047cf9514a2a702e62e859611c5311L23-R33): Updated error messages to reflect the new `api` and `version` fields instead of `Category` and `Version`. [[1]](diffhunk://#diff-ab12a9e962ff1a451856f9c7105c30fb80047cf9514a2a702e62e859611c5311L23-R33) [[2]](diffhunk://#diff-ab12a9e962ff1a451856f9c7105c30fb80047cf9514a2a702e62e859611c5311L47-R57) [[3]](diffhunk://#diff-ab12a9e962ff1a451856f9c7105c30fb80047cf9514a2a702e62e859611c5311L71-R71) [[4]](diffhunk://#diff-ab12a9e962ff1a451856f9c7105c30fb80047cf9514a2a702e62e859611c5311L81-R89)

### Test updates:

* [`cav/endpoint_options_test.go`](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L26-R26): Updated test cases to use the new `api` and `version` fields in endpoint initialization and validation. [[1]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L26-R26) [[2]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L39-R39) [[3]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L52-R52) [[4]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L69-R69) [[5]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L86-R86) [[6]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L100-R100) [[7]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L117-R117) [[8]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L131-R131) [[9]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L148-R148) [[10]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L160-R160) [[11]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L174-R174) [[12]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L188-R188) [[13]](diffhunk://#diff-4d856cf9cbf09159ad77846c22711455323895898caf4f3367fba54d80934f22L205-R205)