### PR TITLE
feat: migrate pkg URN from V1 & rename Gateway to EdgeGateway

### DIFF
--- a/pkg/urn/urn.go
+++ b/pkg/urn/urn.go
@@ -100,6 +100,8 @@ type (
 	URN string
 )
 
+var uuidRegex = regexp.MustCompile(`^([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$`)
+
 // String returns the string representation of the URN.
 func (urn URN) String() string {
 	return string(urn)
@@ -120,7 +122,7 @@ func (urn URN) isEmpty() bool {
 }
 
 func isUUIDV4(urn string) bool {
-	return regexp.MustCompile(`^([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$`).MatchString(urn)
+	return uuidRegex.MatchString(urn)
 }
 
 func IsUUIDV4(urn string) bool {

--- a/pkg/urn/urn.go
+++ b/pkg/urn/urn.go
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// Prefixes is the list of prefixes.
+	VcloudPrefix      = "urn:vcloud:"
+	CloudAvenuePrefix = "urn:cloudavenue:"
+
+	// * VCD.
+	Org                        = URN(VcloudPrefix + "org:")
+	VM                         = URN(VcloudPrefix + "vm:")
+	User                       = URN(VcloudPrefix + "user:")
+	Group                      = URN(VcloudPrefix + "group:")
+	EdgeGateway                = URN(VcloudPrefix + "gateway:")
+	VDC                        = URN(VcloudPrefix + "vdc:")
+	VDCGroup                   = URN(VcloudPrefix + "vdcGroup:")
+	VDCComputePolicy           = URN(VcloudPrefix + "vdcComputePolicy:")
+	Network                    = URN(VcloudPrefix + "network:")
+	VDCStorageProfile          = URN(VcloudPrefix + "vdcstorageProfile:")
+	VAPP                       = URN(VcloudPrefix + "vapp:")
+	VAPPTemplate               = URN(VcloudPrefix + "vappTemplate:")
+	Disk                       = URN(VcloudPrefix + "disk:")
+	SecurityGroup              = URN(VcloudPrefix + "firewallGroup:")
+	Catalog                    = URN(VcloudPrefix + "catalog:")
+	Token                      = URN(VcloudPrefix + "token:")
+	AppPortProfile             = URN(VcloudPrefix + "applicationPortProfile:")
+	CertificateLibraryItem     = URN(VcloudPrefix + "certificateLibraryItem:")
+	LoadBalancerPool           = URN(VcloudPrefix + "loadBalancerPool:")
+	LoadBalancerVirtualService = URN(VcloudPrefix + "loadBalancerVirtualService:")
+	ServiceEngineGroup         = URN(VcloudPrefix + "serviceEngineGroup:")
+
+	// * CLOUDAVENUE.
+	VCDA = URN(CloudAvenuePrefix + "vcda:")
+)
+
+var URNs = []URN{
+	Org,
+	VM,
+	User,
+	Group,
+	EdgeGateway,
+	VDC,
+	VDCGroup,
+	VDCComputePolicy,
+	Network,
+	VDCStorageProfile,
+	VAPP,
+	VAPPTemplate,
+	Disk,
+	SecurityGroup,
+	Catalog,
+	Token,
+	AppPortProfile,
+	CertificateLibraryItem,
+	LoadBalancerPool,
+	LoadBalancerVirtualService,
+	ServiceEngineGroup,
+	VCDA,
+}
+
+var URNByNames = map[string]URN{
+	"org":                        Org,
+	"vm":                         VM,
+	"user":                       User,
+	"group":                      Group,
+	"edgeGateway":                EdgeGateway,
+	"vdc":                        VDC,
+	"vdcGroup":                   VDCGroup,
+	"vdcComputePolicy":           VDCComputePolicy,
+	"network":                    Network,
+	"vdcstorageProfile":          VDCStorageProfile,
+	"vapp":                       VAPP,
+	"vappTemplate":               VAPPTemplate,
+	"disk":                       Disk,
+	"firewallGroup":              SecurityGroup,
+	"catalog":                    Catalog,
+	"token":                      Token,
+	"applicationPortProfile":     AppPortProfile,
+	"certificateLibraryItem":     CertificateLibraryItem,
+	"loadBalancerPool":           LoadBalancerPool,
+	"loadBalancerVirtualService": LoadBalancerVirtualService,
+	"serviceEngineGroup":         ServiceEngineGroup,
+	"vcda":                       VCDA,
+}
+
+type (
+	URN string
+)
+
+// String returns the string representation of the URN.
+func (urn URN) String() string {
+	return string(urn)
+}
+
+// IsType returns true if the URN is of the specified type.
+func (urn URN) IsType(prefix URN) bool {
+	if urn.isEmpty() || prefix.isEmpty() {
+		return false
+	}
+
+	return strings.HasPrefix(string(urn), prefix.String()) && isUUIDV4(urn.extractUUIDv4(prefix))
+}
+
+// isEmpty returns true if the URN is empty.
+func (urn URN) isEmpty() bool {
+	return len(urn) == 0
+}
+
+func isUUIDV4(urn string) bool {
+	return regexp.MustCompile(`^([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})$`).MatchString(urn)
+}
+
+func IsUUIDV4(urn string) bool {
+	return isUUIDV4(urn)
+}
+
+// ContainsPrefix returns true if the URN contains any prefix.
+func (urn URN) ContainsPrefix() bool {
+	return strings.Contains(string(urn), string(VcloudPrefix)) || strings.Contains(string(urn), string(CloudAvenuePrefix))
+}
+
+// extractUUIDv4 returns the UUIDv4 from the URN.
+func (urn URN) extractUUIDv4(prefix URN) string {
+	return extractUUIDv4(urn.String(), prefix)
+}
+
+func extractUUIDv4(urn string, prefix URN) string {
+	if len(urn) == 0 || prefix.isEmpty() {
+		return ""
+	}
+
+	return urn[len(prefix):]
+}

--- a/pkg/urn/urn_common.go
+++ b/pkg/urn/urn_common.go
@@ -11,13 +11,17 @@ package urn
 
 import "regexp"
 
+var extractUUIDv4Regex = regexp.MustCompile(`([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`)
+
 // ExtractUUID finds an UUID in the input string
 // Returns an empty string if no UUID was found.
 func ExtractUUID(input string) string {
-	reGetID := regexp.MustCompile(`([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`)
-	matchListIDs := reGetID.FindAllStringSubmatch(input, -1)
-	if len(matchListIDs) > 0 && len(matchListIDs[0]) > 0 {
-		return matchListIDs[len(matchListIDs)-1][len(matchListIDs[0])-1]
+	matchListIDs := extractUUIDv4Regex.FindAllStringSubmatch(input, -1)
+	// matchListIDs contains all matches of the regular expression in the input string.
+	// Each match is a slice where the first element is the full match and subsequent elements are capture groups.
+	if len(matchListIDs) > 0 && len(matchListIDs[0]) > 1 {
+		// Return the first match's first capture group (UUID).
+		return matchListIDs[0][1]
 	}
 	return ""
 }

--- a/pkg/urn/urn_common.go
+++ b/pkg/urn/urn_common.go
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+import "regexp"
+
+// ExtractUUID finds an UUID in the input string
+// Returns an empty string if no UUID was found.
+func ExtractUUID(input string) string {
+	reGetID := regexp.MustCompile(`([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`)
+	matchListIDs := reGetID.FindAllStringSubmatch(input, -1)
+	if len(matchListIDs) > 0 && len(matchListIDs[0]) > 0 {
+		return matchListIDs[len(matchListIDs)-1][len(matchListIDs[0])-1]
+	}
+	return ""
+}
+
+// IsValid returns true if the URN is valid.
+// Checks if the URN is of the specified type and if it is a valid UUIDv4.
+func IsValid(urn string) bool {
+	if len(urn) == 0 {
+		return false
+	}
+
+	u := URN(urn)
+
+	for _, prefix := range URNs {
+		// Check if the URN is of the specified type.
+		if u.IsType(prefix) {
+			// Check if the URN is a valid UUIDv4.
+			return isUUIDV4(extractUUIDv4(urn, prefix))
+		}
+	}
+	return false
+}
+
+// Normalize returns the URN with the prefix if prefix is missing.
+func Normalize(prefix URN, uuid string) URN {
+	u := URN(uuid)
+	if u.ContainsPrefix() {
+		return u
+	}
+
+	if prefix.isEmpty() {
+		return ""
+	}
+
+	return prefix + u
+}

--- a/pkg/urn/urn_common_test.go
+++ b/pkg/urn/urn_common_test.go
@@ -1,0 +1,114 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+import "testing"
+
+func TestNormalize(t *testing.T) {
+	type args struct {
+		prefix URN
+		uuid   string
+	}
+	tests := []struct {
+		name string
+		args args
+		want URN
+	}{
+		{
+			name: "Normalize",
+			args: args{
+				prefix: VM,
+				uuid:   validUUIDv4,
+			},
+			want: URN(VM.String() + validUUIDv4),
+		},
+		// Check prefix is empty
+		{
+			name: "EmptyPrefix",
+			args: args{
+				prefix: "",
+				uuid:   validUUIDv4,
+			},
+			want: "",
+		},
+		// Check uuid is already an URN
+		{
+			name: "AlreadyURN",
+			args: args{
+				prefix: VM,
+				uuid:   VM.String() + validUUIDv4,
+			},
+			want: URN(VM.String() + validUUIDv4),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Normalize(tt.args.prefix, tt.args.uuid); got != tt.want {
+				t.Errorf("Normalize() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractUUID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "ValidUUID",
+			input: "This is a string with a UUID 123e4567-e89b-12d3-a456-426614174000 inside",
+			want:  "123e4567-e89b-12d3-a456-426614174000",
+		},
+		{
+			name:  "NoUUID",
+			input: "This string does not contain a UUID",
+			want:  "",
+		},
+		{
+			name:  "ValidUUIDInURN",
+			input: "urn:vcloud:vm:123e4567-e89b-12d3-a456-426614174000",
+			want:  "123e4567-e89b-12d3-a456-426614174000",
+		},
+		{
+			name:  "ValidUUID in URL",
+			input: "https://example.com/123e4567-e89b-12d3-a456-426614174000",
+			want:  "123e4567-e89b-12d3-a456-426614174000",
+		},
+		{
+			name:  "ValidUUID in URL with URN format",
+			input: "https://example.com/urn:vcloud:vm:123e4567-e89b-12d3-a456-426614174000",
+			want:  "123e4567-e89b-12d3-a456-426614174000",
+		},
+		{
+			name:  "ValidUUID in URL with URN format and query",
+			input: "https://example.com/urn:vcloud:vm:123e4567-e89b-12d3-a456-426614174000?page=10",
+			want:  "123e4567-e89b-12d3-a456-426614174000",
+		},
+		{
+			name:  "InvalidUUIDFormat",
+			input: "This string contains an invalid UUID 123e4567-e89b-12d3-a456-42661417400Z",
+			want:  "",
+		},
+		{
+			name:  "EmptyString",
+			input: "",
+			want:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExtractUUID(tt.input); got != tt.want {
+				t.Errorf("ExtractUUID() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/urn/urn_helpers.go
+++ b/pkg/urn/urn_helpers.go
@@ -34,12 +34,12 @@ func TestIsType(urnType URN) resource.CheckResourceAttrWithFunc {
 // FindURNTypeFromString returns the URN type from a string.
 func FindURNTypeFromString(value string) (URN, error) {
 	if value == "" {
-		return "", errors.New("value doesn't contains an URN type provided")
+		return "", errors.New("value does not contain an URN type provided")
 	}
 
 	if u, ok := URNByNames[value]; ok {
 		return u, nil
 	}
 
-	return "", fmt.Errorf("URN type %s doesn't exist by package urn", value)
+	return "", fmt.Errorf("URN type %s does not exist in package urn", value)
 }

--- a/pkg/urn/urn_helpers.go
+++ b/pkg/urn/urn_helpers.go
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Special functions for the terraform provider test.
+// TestIsType returns true if the URN is of the specified type.
+func TestIsType(urnType URN) resource.CheckResourceAttrWithFunc {
+	return func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		if !URN(value).IsType(urnType) {
+			return fmt.Errorf("urn %s is not of type %s", value, urnType)
+		}
+		return nil
+	}
+}
+
+// FindURNTypeFromString returns the URN type from a string.
+func FindURNTypeFromString(value string) (URN, error) {
+	if value == "" {
+		return "", errors.New("value doesn't contains an URN type provided")
+	}
+
+	if u, ok := URNByNames[value]; ok {
+		return u, nil
+	}
+
+	return "", fmt.Errorf("URN type %s doesn't exist by package urn", value)
+}

--- a/pkg/urn/urn_helpers_test.go
+++ b/pkg/urn/urn_helpers_test.go
@@ -1,0 +1,60 @@
+package urn
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFindURNTypeFromString(t *testing.T) {
+	// Setup a fake URNByNames for testing
+	URNByNames = map[string]URN{
+		"test-type": "test-type",
+	}
+
+	tests := []struct {
+		name      string
+		input     string
+		want      URN
+		wantErr   bool
+		errString string
+	}{
+		{
+			name:      "empty value",
+			input:     "",
+			want:      "",
+			wantErr:   true,
+			errString: "value doesn't contains an URN type provided",
+		},
+		{
+			name:    "existing type",
+			input:   "test-type",
+			want:    "test-type",
+			wantErr: false,
+		},
+		{
+			name:      "non-existing type",
+			input:     "not-exist",
+			want:      "",
+			wantErr:   true,
+			errString: "URN type not-exist doesn't exist by package urn",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := FindURNTypeFromString(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("FindURNTypeFromString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("FindURNTypeFromString() = %v, want %v", got, tt.want)
+			}
+			if tt.wantErr && err != nil && tt.errString != "" {
+				if !errors.Is(err, errors.New(tt.errString)) && err.Error() != tt.errString {
+					t.Errorf("FindURNTypeFromString() error = %v, want %v", err, tt.errString)
+				}
+			}
+		})
+	}
+}

--- a/pkg/urn/urn_helpers_test.go
+++ b/pkg/urn/urn_helpers_test.go
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
 package urn
 
 import (

--- a/pkg/urn/urn_helpers_test.go
+++ b/pkg/urn/urn_helpers_test.go
@@ -32,7 +32,7 @@ func TestFindURNTypeFromString(t *testing.T) {
 			input:     "",
 			want:      "",
 			wantErr:   true,
-			errString: "value doesn't contains an URN type provided",
+			errString: "value does not contain an URN type provided",
 		},
 		{
 			name:    "existing type",
@@ -45,7 +45,7 @@ func TestFindURNTypeFromString(t *testing.T) {
 			input:     "not-exist",
 			want:      "",
 			wantErr:   true,
-			errString: "URN type not-exist doesn't exist by package urn",
+			errString: "URN type not-exist does not exist in package urn",
 		},
 	}
 

--- a/pkg/urn/urn_is_funcs.go
+++ b/pkg/urn/urn_is_funcs.go
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+// IsAppPortProfile returns true if the URN is a AppPortProfile URN.
+func IsAppPortProfile(urn string) bool {
+	return URN(urn).IsType(AppPortProfile)
+}
+
+// IsOrg returns true if the URN is an Org URN.
+func IsOrg(urn string) bool {
+	return URN(urn).IsType(Org)
+}
+
+// IsEdgeGateway returns true if the URN is a EdgeGateway URN.
+func IsEdgeGateway(urn string) bool {
+	return URN(urn).IsType(EdgeGateway)
+}
+
+// IsVDC returns true if the URN is a VDC URN.
+func IsVDC(urn string) bool {
+	return URN(urn).IsType(VDC)
+}
+
+// IsVDCGroup returns true if the URN is a VDCGroup URN.
+func IsVDCGroup(urn string) bool {
+	return URN(urn).IsType(VDCGroup)
+}
+
+// IsNetwork returns true if the URN is a Network URN.
+func IsNetwork(urn string) bool {
+	return URN(urn).IsType(Network)
+}
+
+// IsLoadBalancerPool returns true if the URN is a LoadBalancerPool URN.
+func IsLoadBalancerPool(urn string) bool {
+	return URN(urn).IsType(LoadBalancerPool)
+}
+
+// IsVDCStorageProfile returns true if the URN is a VDCStorageProfile URN.
+func IsVDCStorageProfile(urn string) bool {
+	return URN(urn).IsType(VDCStorageProfile)
+}
+
+// IsVAPP returns true if the URN is a VAPP URN.
+func IsVAPP(urn string) bool {
+	return URN(urn).IsType(VAPP)
+}
+
+// IsVAPPTemplate returns true if the URN is a VAPPTemplate URN.
+func IsVAPPTemplate(urn string) bool {
+	return URN(urn).IsType(VAPPTemplate)
+}
+
+// IsDisk returns true if the URN is a Disk URN.
+func IsDisk(urn string) bool {
+	return URN(urn).IsType(Disk)
+}
+
+// IsSecurityGroup returns true if the URN is a SecurityGroup URN.
+func IsSecurityGroup(urn string) bool {
+	return URN(urn).IsType(SecurityGroup)
+}
+
+// IsVCDA returns true if the URN is a VCDA URN.
+func IsVCDA(urn string) bool {
+	return URN(urn).IsType(VCDA)
+}
+
+// IsVM returns true if the URN is a VM URN.
+func IsVM(urn string) bool {
+	return URN(urn).IsType(VM)
+}
+
+// IsUser returns true if the URN is a User URN.
+func IsUser(urn string) bool {
+	return URN(urn).IsType(User)
+}
+
+// IsGroup returns true if the URN is a Group URN.
+func IsGroup(urn string) bool {
+	return URN(urn).IsType(Group)
+}
+
+// IsCatalog returns true if the URN is a Catalog URN.
+func IsCatalog(urn string) bool {
+	return URN(urn).IsType(Catalog)
+}
+
+// IsToken returns true if the URN is a Token URN.
+func IsToken(urn string) bool {
+	return URN(urn).IsType(Token)
+}
+
+// IsVDCComputePolicy returns true if the URN is a VDCComputePolicy URN.
+func IsVDCComputePolicy(urn string) bool {
+	return URN(urn).IsType(VDCComputePolicy)
+}
+
+// IsCertificateLibraryItem returns true if the URN is a CertificateLibraryItem URN.
+func IsCertificateLibraryItem(urn string) bool {
+	return URN(urn).IsType(CertificateLibraryItem)
+}
+
+// IsLoadBalancerVirtualService returns true if the URN is a LoadBalancerVirtualService URN.
+func IsLoadBalancerVirtualService(urn string) bool {
+	return URN(urn).IsType(LoadBalancerVirtualService)
+}
+
+// IsServiceEngineGroup returns true if the URN is a ServiceEngineGroup URN.
+func IsServiceEngineGroup(urn string) bool {
+	return URN(urn).IsType(ServiceEngineGroup)
+}

--- a/pkg/urn/urn_is_funcs_test.go
+++ b/pkg/urn/urn_is_funcs_test.go
@@ -1,0 +1,755 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+import "testing"
+
+func TestIsGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{
+			name: "IsGroup",
+			urn:  URN(Group.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGroup(tt.urn.String()); got != tt.want {
+				t.Errorf("IsGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsGateway.
+func TestIsEdgeGateway(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{
+			name: "IsGateway",
+			urn:  URN(EdgeGateway.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotGateway",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsEdgeGateway(tt.urn.String()); got != tt.want {
+				t.Errorf("IsEdgeGateway() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVDC.
+func TestIsVDC(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{
+			name: "IsVDC",
+			urn:  URN(VDC.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotVDC",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVDC(tt.urn.String()); got != tt.want {
+				t.Errorf("IsVDC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVDCGroup.
+func TestIsVDCGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{
+			name: "IsVDCGroup",
+			urn:  URN(VDCGroup.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotVDCGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVDCGroup(tt.urn.String()); got != tt.want {
+				t.Errorf("IsVDCGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsNetwork.
+func TestIsNetwork(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{
+			name: "IsNetwork",
+			urn:  URN(Network.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotNetwork",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNetwork(tt.urn.String()); got != tt.want {
+				t.Errorf("IsNetwork() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsLoadBalancerPool.
+func TestIsLoadBalancerPool(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{ // IsLoadBalancerPool
+			name: "IsLoadBalancerPool",
+			urn:  URN(LoadBalancerPool.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotLoadBalancerPool
+			name: "IsNotLoadBalancerPool",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLoadBalancerPool(tt.urn.String()); got != tt.want {
+				t.Errorf("IsLoadBalancerPool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVDCStorageProfile.
+func TestIsVDCStorageProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{ // IsVDCStorageProfile
+			name: "IsVDCStorageProfile",
+			urn:  URN(VDCStorageProfile.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotVDCStorageProfile
+			name: "IsNotVDCStorageProfile",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVDCStorageProfile(tt.urn.String()); got != tt.want {
+				t.Errorf("IsVDCStorageProfile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVAPP.
+func TestIsVAPP(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsVAPP
+			name: "IsVAPP",
+			urn:  URN(VAPP.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotVAPP
+			name: "IsNotVAPP",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVAPP(tt.urn); got != tt.want {
+				t.Errorf("IsVAPP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsDisk.
+func TestIsDisk(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsDisk
+			name: "IsDisk",
+			urn:  URN(Disk.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotDisk
+			name: "IsNotDisk",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDisk(tt.urn); got != tt.want {
+				t.Errorf("IsDisk() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsSecurityGroup.
+func TestIsSecurityGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsSecurityGroup
+			name: "IsSecurityGroup",
+			urn:  URN(SecurityGroup.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotSecurityGroup
+			name: "IsNotSecurityGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSecurityGroup(tt.urn); got != tt.want {
+				t.Errorf("IsSecurityGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsVCDA.
+func TestIsVCDA(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsVCDA
+			name: "IsVCDA",
+			urn:  URN(VCDA.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotVCDA
+			name: "IsNotVCDA",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVCDA(tt.urn); got != tt.want {
+				t.Errorf("IsVCDA() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsVM.
+func TestIsVM(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsVM
+			name: "IsVM",
+			urn:  URN(VM.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotVM
+			name: "IsNotVM",
+			urn:  URN("urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVM(tt.urn); got != tt.want {
+				t.Errorf("IsVM() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsUser.
+func TestIsUser(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsUser
+			name: "IsUser",
+			urn:  URN(User.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotUser
+			name: "IsNotUser",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUser(tt.urn); got != tt.want {
+				t.Errorf("IsUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsOrg.
+func TestIsOrg(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsOrg
+			name: "IsOrg",
+			urn:  URN(Org.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotOrg
+			name: "IsNotOrg",
+			urn:  URN("urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOrg(tt.urn); got != tt.want {
+				t.Errorf("IsOrg() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsToken.
+func TestIsToken(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsToken
+			name: "IsToken",
+			urn:  URN(Token.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotToken
+			name: "IsNotToken",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsToken(tt.urn); got != tt.want {
+				t.Errorf("IsToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsAppPortProfile.
+func TestIsAppPortProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsAppPortProfile
+			name: "IsAppPortProfile",
+			urn:  URN(AppPortProfile.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotAppPortProfile
+			name: "IsNotAppPortProfile",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsAppPortProfile(tt.urn); got != tt.want {
+				t.Errorf("IsAppPortProfile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsVDCComputePolicy.
+func TestIsVDCComputePolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsVDCComputePolicy
+			name: "IsVDCComputePolicy",
+			urn:  URN(VDCComputePolicy.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotVDCComputePolicy
+			name: "IsNotVDCComputePolicy",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVDCComputePolicy(tt.urn); got != tt.want {
+				t.Errorf("IsAppPortProfile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsCatalog.
+func TestIsCatalog(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsCatalog
+			name: "IsCatalog",
+			urn:  URN(Catalog.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotCatalog
+			name: "IsNotCatalog",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCatalog(tt.urn); got != tt.want {
+				t.Errorf("IsCatalog() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsVAPPTemplate.
+func TestIsVAPPTemplate(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsVAPPTemplate
+			name: "IsVAPPTemplate",
+			urn:  URN(VAPPTemplate.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotVAPPTemplate
+			name: "IsNotVAPPTemplate",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsVAPPTemplate(tt.urn); got != tt.want {
+				t.Errorf("IsVAPPTemplate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsCertificateLibraryItem.
+func TestIsCertificateLibraryItem(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsCertificateLibraryItem
+			name: "IsCertificateLibraryItem",
+			urn:  URN(CertificateLibraryItem.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotCertificateLibraryItem
+			name: "IsNotCertificateLibraryItem",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsCertificateLibraryItem(tt.urn); got != tt.want {
+				t.Errorf("IsCertificateLibraryItem() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsLoadBalancerVirtualService.
+func TestIsLoadBalancerVirtualService(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsLoadBalancerVirtualService
+			name: "IsLoadBalancerVirtualService",
+			urn:  URN(LoadBalancerVirtualService.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotLoadBalancerVirtualService
+			name: "IsNotLoadBalancerVirtualService",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsLoadBalancerVirtualService(tt.urn); got != tt.want {
+				t.Errorf("IsLoadBalancerVirtualService() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsServiceEngineGroup.
+func TestIsServiceEngineGroup(t *testing.T) {
+	tests := []struct {
+		name    string
+		urnType URN
+		urn     string
+		want    bool
+	}{
+		{ // IsServiceEngineGroup
+			name: "IsServiceEngineGroup",
+			urn:  URN(ServiceEngineGroup.String() + validUUIDv4).String(),
+			want: true,
+		},
+		{ // IsNotServiceEngineGroup
+			name: "IsNotServiceEngineGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479").String(),
+			want: false,
+		},
+		{ // EmptyString
+			name: "EmptyString",
+			urn:  URN("").String(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsServiceEngineGroup(tt.urn); got != tt.want {
+				t.Errorf("IsServiceEngineGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/urn/urn_is_methods.go
+++ b/pkg/urn/urn_is_methods.go
@@ -1,0 +1,120 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+// IsAppPortProfile returns true if the URN is a AppPortProfile URN.
+func (urn URN) IsAppPortProfile() bool {
+	return urn.IsType(AppPortProfile)
+}
+
+// IsOrg returns true if the URN is an Org URN.
+func (urn URN) IsOrg() bool {
+	return urn.IsType(Org)
+}
+
+// IsVM returns true if the URN is a VM URN.
+func (urn URN) IsVM() bool {
+	return urn.IsType(VM)
+}
+
+// IsUser returns true if the URN is a User URN.
+func (urn URN) IsUser() bool {
+	return urn.IsType(User)
+}
+
+// IsGroup returns true if the URN is a Group URN.
+func (urn URN) IsGroup() bool {
+	return urn.IsType(Group)
+}
+
+// IsEdgeGateway returns true if the URN is an EdgeGateway URN.
+func (urn URN) IsEdgeGateway() bool {
+	return urn.IsType(EdgeGateway)
+}
+
+// IsVDC returns true if the URN is a VDC URN.
+func (urn URN) IsVDC() bool {
+	return urn.IsType(VDC)
+}
+
+// IsVDCGroup returns true if the URN is a VDCGroup URN.
+func (urn URN) IsVDCGroup() bool {
+	return urn.IsType(VDCGroup)
+}
+
+// IsNetwork returns true if the URN is a Network URN.
+func (urn URN) IsNetwork() bool {
+	return urn.IsType(Network)
+}
+
+// IsLoadBalancerPool returns true if the URN is a LoadBalancerPool URN.
+func (urn URN) IsLoadBalancerPool() bool {
+	return urn.IsType(LoadBalancerPool)
+}
+
+// IsVDCStorageProfile returns true if the URN is a VDCStorageProfile URN.
+func (urn URN) IsVDCStorageProfile() bool {
+	return urn.IsType(VDCStorageProfile)
+}
+
+// IsVAPP returns true if the URN is a VAPP URN.
+func (urn URN) IsVAPP() bool {
+	return urn.IsType(VAPP)
+}
+
+// IsVAPPTemplate returns true if the URN is a VAPPTemplate URN.
+func (urn URN) IsVAPPTemplate() bool {
+	return urn.IsType(VAPPTemplate)
+}
+
+// IsDisk returns true if the URN is a Disk URN.
+func (urn URN) IsDisk() bool {
+	return urn.IsType(Disk)
+}
+
+// IsSecurityGroup returns true if the URN is a SecurityGroup URN.
+func (urn URN) IsSecurityGroup() bool {
+	return urn.IsType(SecurityGroup)
+}
+
+// IsCatalog returns true if the URN is a Catalog URN.
+func (urn URN) IsCatalog() bool {
+	return urn.IsType(Catalog)
+}
+
+// IsToken returns true if the URN is a Token URN.
+func (urn URN) IsToken() bool {
+	return urn.IsType(Token)
+}
+
+// IsVDCComputePolicy returns true if the URN is a VDCComputePolicy URN.
+func (urn URN) IsVDCComputePolicy() bool {
+	return urn.IsType(VDCComputePolicy)
+}
+
+// IsCertificateLibraryItem returns true if the URN is a CertificateLibraryItem URN.
+func (urn URN) IsCertificateLibraryItem() bool {
+	return urn.IsType(CertificateLibraryItem)
+}
+
+// IsLoadBalancerVirtualService returns true if the URN is a LoadBalancerVirtualService URN.
+func (urn URN) IsLoadBalancerVirtualService() bool {
+	return urn.IsType(LoadBalancerVirtualService)
+}
+
+// IsServiceEngineGroup returns true if the URN is a ServiceEngineGroup URN.
+func (urn URN) IsServiceEngineGroup() bool {
+	return urn.IsType(ServiceEngineGroup)
+}
+
+// IsVCDA returns true if the URN is a VCDA URN.
+func (urn URN) IsVCDA() bool {
+	return urn.IsType(VCDA)
+}

--- a/pkg/urn/urn_is_methods_test.go
+++ b/pkg/urn/urn_is_methods_test.go
@@ -1,0 +1,746 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+import "testing"
+
+func TestURN_IsVM(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsVM",
+			urn:  URN(VM.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotVM",
+			urn:  URN("urn:vcloud:user:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVM(); got != tt.want {
+				t.Errorf("URN.IsVM() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURN_IsUser(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsUser",
+			urn:  URN(User.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotUser",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsUser(); got != tt.want {
+				t.Errorf("URN.IsUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsGroup.
+func TestURN_IsGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsGroup",
+			urn:  URN(Group.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsGroup(); got != tt.want {
+				t.Errorf("URN.IsGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsEdgeGateway.
+func TestURN_IsEdgeGateway(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsEdgeGateway",
+			urn:  URN(EdgeGateway.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotEdgeGateway",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsEdgeGateway(); got != tt.want {
+				t.Errorf("URN.IsEdgeGateway() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsAppPortProfile tests the IsAppProfile function.
+func TestURN_IsAppPortProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsAppProfile
+			name: "IsAppProfile",
+			urn:  URN(AppPortProfile.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotAppProfile
+			name: "IsNotAppProfile",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsAppPortProfile(); got != tt.want {
+				t.Errorf("URN.IsAppPortProfile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVDC.
+func TestURN_IsVDC(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsVDC",
+			urn:  URN(VDC.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotVDC",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVDC(); got != tt.want {
+				t.Errorf("URN.IsVDC() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVDCGroup.
+func TestURN_IsVDCGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsVDCGroup
+			name: "IsVDCGroup",
+			urn:  URN(VDCGroup.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotVDCGroup
+			name: "IsNotVDCGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVDCGroup(); got != tt.want {
+				t.Errorf("URN.IsVDCGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsNetwork.
+func TestURN_IsNetwork(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsNetwork",
+			urn:  URN(Network.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotNetwork",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsNetwork(); got != tt.want {
+				t.Errorf("URN.IsNetwork() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsLoadBalancerPool.
+func TestURN_IsLoadBalancerPool(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsLoadBalancerPool",
+			urn:  URN(LoadBalancerPool.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotLoadBalancerPool",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsLoadBalancerPool(); got != tt.want {
+				t.Errorf("URN.IsLoadBalancerPool() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVDCStorageProfile.
+func TestURN_IsVDCStorageProfile(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsVDCStorageProfile",
+			urn:  URN(VDCStorageProfile.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotVDCStorageProfile",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVDCStorageProfile(); got != tt.want {
+				t.Errorf("URN.IsVDCStorageProfile() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVAPP.
+func TestURN_IsVAPP(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsVAPP",
+			urn:  URN(VAPP.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotVAPP",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVAPP(); got != tt.want {
+				t.Errorf("URN.IsVAPP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsDisk.
+func TestURN_IsDisk(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsDisk",
+			urn:  URN(Disk.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotDisk",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsDisk(); got != tt.want {
+				t.Errorf("URN.IsDisk() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsSecurityGroup.
+func TestURN_IsSecurityGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "IsSecurityGroup",
+			urn:  URN(SecurityGroup.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "IsNotSecurityGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d479"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsSecurityGroup(); got != tt.want {
+				t.Errorf("URN.IsSecurityGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsVAPPTemplate.
+func TestURN_IsVAPPTemplate(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsVAPPTemplate
+			name: "IsVAPPTemplate",
+			urn:  URN(VAPPTemplate.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotVAPPTemplate
+			name: "IsNotVAPPTemplate",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVAPPTemplate(); got != tt.want {
+				t.Errorf("URN.IsVAPPTemplate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsCatalog.
+func TestURN_IsCatalog(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsCatalog
+			name: "IsCatalog",
+			urn:  URN(Catalog.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotCatalog
+			name: "IsNotCatalog",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsCatalog(); got != tt.want {
+				t.Errorf("URN.IsCatalog() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsToken.
+func TestURN_IsToken(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsToken
+			name: "IsToken",
+			urn:  URN(Token.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotToken
+			name: "IsNotToken",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsToken(); got != tt.want {
+				t.Errorf("URN.IsToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// IsCatalog.
+func TestVcloudURN_IsCatalog(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsCatalog
+			name: "IsCatalog",
+			urn:  URN(Catalog.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotCatalog
+			name: "IsNotCatalog",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsCatalog(); got != tt.want {
+				t.Errorf("VcloudURN.IsCatalog() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestURN_IsOrg tests the URN.IsOrg function.
+func TestURN_IsOrg(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsOrg
+			name: "IsOrg",
+			urn:  URN(Org.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotOrg
+			name: "IsNotOrg",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsOrg(); got != tt.want {
+				t.Errorf("URN.IsOrg() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestURN_IsVDCComputePolicy tests the URN.IsVDCComputePolicy function.
+func TestURN_IsVDCComputePolicy(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsVDCComputePolicy
+			name: "IsVDCComputePolicy",
+			urn:  URN(VDCComputePolicy.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotVDCComputePolicy
+			name: "IsNotVDCComputePolicy",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVDCComputePolicy(); got != tt.want {
+				t.Errorf("URN.IsVDCComputePolicy() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestURN_IsLoadBalancerVirtualService tests the URN.IsLoadBalancerVirtualService function.
+func TestURN_IsLoadBalancerVirtualService(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsLoadBalancerVirtualService
+			name: "IsLoadBalancerVirtualService",
+			urn:  URN(LoadBalancerVirtualService.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotLoadBalancerVirtualService
+			name: "IsNotLoadBalancerVirtualService",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsLoadBalancerVirtualService(); got != tt.want {
+				t.Errorf("URN.IsLoadBalancerVirtualService() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestURN_IsCertificateLibraryItem tests the URN.IsCertificateLibraryItem function.
+func TestURN_IsCertificateLibraryItem(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsCertificateLibraryItem
+			name: "IsCertificateLibraryItem",
+			urn:  URN(CertificateLibraryItem.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotCertificateLibraryItem
+			name: "IsNotCertificateLibraryItem",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsCertificateLibraryItem(); got != tt.want {
+				t.Errorf("URN.IsCertificateLibraryItem() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestURN_IsServiceEngineGroup tests the URN.IsServiceEngineGroup function.
+func TestURN_IsServiceEngineGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsServiceEngineGroup
+			name: "IsServiceEngineGroup",
+			urn:  URN(ServiceEngineGroup.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotServiceEngineGroup
+			name: "IsNotServiceEngineGroup",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsServiceEngineGroup(); got != tt.want {
+				t.Errorf("URN.IsServiceEngineGroup() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestURN_IsVCDA tests the URN.IsVCDA function.
+func TestURN_IsVCDA(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{ // IsVCDA
+			name: "IsVCDA",
+			urn:  URN(VCDA.String() + validUUIDv4),
+			want: true,
+		},
+		{ // IsNotVCDA
+			name: "IsNotVCDA",
+			urn:  URN("urn:vcloud:vm:f47ac10b-58cc-4372-a567-0e02b2c3d4791"),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsVCDA(); got != tt.want {
+				t.Errorf("URN.IsVCDA() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/urn/urn_test.go
+++ b/pkg/urn/urn_test.go
@@ -1,0 +1,295 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package urn
+
+import (
+	"testing"
+)
+
+const (
+	validUUIDv4 = "12345678-1234-1234-1234-123456789012"
+)
+
+func TestURN_ContainsPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  URN
+		want bool
+	}{
+		{
+			name: "ContainsPrefixVCloud",
+			urn:  URN(VM.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "ContainsPrefixCloudAvenue",
+			urn:  URN(VCDA.String() + validUUIDv4),
+			want: true,
+		},
+		{
+			name: "DoesNotContainPrefix",
+			urn:  URN("urn:vm:" + validUUIDv4),
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.ContainsPrefix(); got != tt.want {
+				t.Errorf("URN.ContainsPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_isURNV4(t *testing.T) {
+	type args struct {
+		urn string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ValidURN",
+			args: args{
+				urn: validUUIDv4,
+			},
+			want: true,
+		},
+		{
+			name: "InvalidURN",
+			args: args{
+				urn: "f47ac10b-58cddc-43-a567-0e02b2c3d4791",
+			},
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			args: args{
+				urn: "",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isUUIDV4(tt.args.urn); got != tt.want {
+				t.Errorf("isUUIDV4() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestURN_IsType(t *testing.T) {
+	type args struct {
+		prefix URN
+	}
+	tests := []struct {
+		name string
+		urn  URN
+		args args
+		want bool
+	}{
+		{
+			name: "IsType",
+			urn:  URN(VM.String() + validUUIDv4),
+			args: args{
+				prefix: VM,
+			},
+			want: true,
+		},
+		{
+			name: "IsNotType",
+			urn:  URN(VM.String() + validUUIDv4),
+			args: args{
+				prefix: User,
+			},
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			urn:  URN(""),
+			args: args{
+				prefix: VM,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.urn.IsType(tt.args.prefix); got != tt.want {
+				t.Errorf("URN.IsType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_extractURNv4(t *testing.T) {
+	type args struct {
+		urn    string
+		prefix URN
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "ExtractURN",
+			args: args{
+				urn:    VM.String() + validUUIDv4,
+				prefix: VM,
+			},
+			want: validUUIDv4,
+		},
+		{
+			name: "EmptyString",
+			args: args{
+				urn:    "",
+				prefix: VM,
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := extractUUIDv4(tt.args.urn, tt.args.prefix); got != tt.want {
+				t.Errorf("extractURNv4() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsValid(t *testing.T) {
+	type args struct {
+		urn string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "ValidURN",
+			args: args{
+				urn: VM.String() + validUUIDv4,
+			},
+			want: true,
+		},
+		{
+			name: "InvalidURN",
+			args: args{
+				urn: "f47ac10b-58cddc-43-a567-0e02b2c3d4791",
+			},
+			want: false,
+		},
+		{
+			name: "InvalidPrefix",
+			args: args{
+				urn: "urn:vm:f47ac10b-58cddc-43-a567-0e02b2c3d4791",
+			},
+			want: false,
+		},
+		{ // Empty string
+			name: "EmptyString",
+			args: args{
+				urn: "",
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValid(tt.args.urn); got != tt.want {
+				t.Errorf("IsValid() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsType tests the TestIsType function.
+func TestTestIsType(t *testing.T) {
+	testCases := []struct {
+		name    string
+		urnType URN
+		urn     URN
+		want    bool
+	}{
+		{
+			name:    "valid urn",
+			urnType: VM,
+			urn:     URN(VM.String() + validUUIDv4),
+			want:    true,
+		},
+		{
+			name:    "invalid urn",
+			urnType: VM,
+			urn:     "invalid-urn",
+			want:    false,
+		},
+		{
+			name:    "empty value",
+			urnType: VM,
+			urn:     "",
+			want:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := TestIsType(tc.urnType)(tc.urn.String())
+			if tc.want && err != nil {
+				t.Errorf("TestIsType() = %v, want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsUUIDV4(t *testing.T) {
+	tests := []struct {
+		name string
+		urn  string
+		want bool
+	}{
+		{
+			name: "ValidUUIDV4",
+			urn:  validUUIDv4,
+			want: true,
+		},
+		{
+			name: "InvalidUUIDV4",
+			urn:  "12345678-1234-1234-1234-12345678901Z",
+			want: false,
+		},
+		{
+			name: "InvalidFormat",
+			urn:  "12345678-1234-1234-1234-1234567890123",
+			want: false,
+		},
+		{
+			name: "EmptyString",
+			urn:  "",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUUIDV4(tt.urn); got != tt.want {
+				t.Errorf("IsUUIDV4() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a comprehensive implementation for handling Uniform Resource Names (URNs) in the `pkg/urn` package. It includes new functionality for defining, validating, extracting, and testing URNs, along with support for specific URN types. The changes are grouped into three main themes: URN functionality, helper methods, and testing.

### URN Functionality

* Added constants and types to define URNs and their prefixes (`pkg/urn/urn.go`). This includes support for `VcloudPrefix` and `CloudAvenuePrefix`, as well as specific URN types such as `VM`, `Org`, `Network`, and others.
* Implemented methods for URN validation, prefix checking, and UUID extraction (`pkg/urn/urn.go`). For example, `IsType`, `ContainsPrefix`, and `extractUUIDv4`.

### Helper Methods

* Added utility functions for URN normalization, validation, and type identification (`pkg/urn/urn_common.go`, `pkg/urn/urn_helpers.go`). This includes `Normalize`, `IsValid`, `ExtractUUID`, and `FindURNTypeFromString`. [[1]](diffhunk://#diff-af1b4595007b754cbc91abfb7f1d51115af22a7f1076117536c7dad9b5cd952aR1-R56) [[2]](diffhunk://#diff-3ec3c6bf1e97ef820a6d7d25a1392055f9e5b027b836b9076e72505541ba83e3R1-R45)
* Provided specialized methods for checking URN types, such as `IsVM`, `IsOrg`, and `IsNetwork`, both as standalone functions and as methods on the `URN` type (`pkg/urn/urn_is_funcs.go`, `pkg/urn/urn_is_methods.go`). [[1]](diffhunk://#diff-8c2e1814792a440e99aa076da717cc7e143cf9b229e3bb3ed2b783111c6b3926R1-R120) [[2]](diffhunk://#diff-a25582a50e8d2801cdaa916babc6e10dcc5e69a8e2aed837bfadc72eca67189bR1-R120)

### Testing

* Added extensive unit tests for all new functionality, including tests for normalization, UUID extraction, type identification, and validation (`pkg/urn/urn_common_test.go`, `pkg/urn/urn_helpers_test.go`, `pkg/urn/urn_test.go`). [[1]](diffhunk://#diff-0b33801209f807aaf870e9a461522b12e7717f5a3c4a479b2ea260dacec84150R1-R114) [[2]](diffhunk://#diff-58730d8232841f27ecb5965e1dd9b504771130357d7c9c3d4de8592d474f7feaR1-R60) [[3]](diffhunk://#diff-fca1d9c5b1fdc0c3c09797e72482e7129deea5183a5cfd20e0b0df276de25aadR1-R295)

These changes significantly enhance the `pkg/urn` package by providing robust support for URN management, validation, and testing.