### PR TITLE
chore: add CODEOWNER file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @orange-cloudavenue/CoreMaintener


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change adds `@orange-cloudavenue/CoreMaintener` as the code owner for all files.