### PR TITLE
feat: add job management for subclient cerberus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 testdata/
 *.out
-api/test
+api/test*

--- a/cav/client_mock_test.go
+++ b/cav/client_mock_test.go
@@ -24,8 +24,8 @@ const (
 )
 
 var pathPrefix = map[SubClientName]string{
-	ClientVmware:         "/cloudapi",
-	ClientCerberus:       "/api/customers",
+	ClientVmware:         "",
+	ClientCerberus:       "",
 	ClientNetbackup:      "/netbackup",
 	SubClientName("ihm"): "/ihm",
 	SubClientName("s3"):  "/s3",
@@ -94,7 +94,7 @@ func newMockClient() (Client, error) {
 			},
 			APICerberus: consoles.Service{
 				Enabled:  true,
-				Endpoint: hts.URL + "/api/customers",
+				Endpoint: hts.URL,
 			},
 			S3: consoles.Service{
 				Enabled:  true,

--- a/cav/client_request.go
+++ b/cav/client_request.go
@@ -48,6 +48,14 @@ func (c *client) NewRequest(ctx context.Context, endpoint *Endpoint, _ ...Reques
 		return nil, err
 	}
 
+	if endpoint.RequestMiddlewares != nil {
+		// If the endpoint has request middlewares, set them on the HTTP client.
+		// This allows for custom processing of the request before it is sent.
+		for _, mw := range endpoint.RequestMiddlewares {
+			hC.AddRequestMiddleware(mw)
+		}
+	}
+
 	// If JobOpts are provided, we need to create a request with job middleware.
 	// This is used to handle job responses and status checks.
 	if endpoint.JobOptions != nil {

--- a/cav/endpoint.go
+++ b/cav/endpoint.go
@@ -87,6 +87,11 @@ type (
 		// To know more about retry see https://resty.dev/docs/retry-mechanism/
 		RetryHooksFuncs []resty.RetryHookFunc
 
+		// RequestMiddleware is a function that takes a resty.Request and returns a resty.Request.
+		// This function is used to modify the request before it is sent.
+		// It allows for adding headers, query parameters, and other modifications to the request.
+		RequestMiddlewares []resty.RequestMiddleware
+
 		// RequestInternalFunc is a function that takes a client and options and returns a resty.Response and an error.
 		// This function is used to make the actual HTTP request (from internal package) to the endpoint.
 		// It allows for customization of the request, such as setting headers, query parameters,

--- a/cav/mock/client.go
+++ b/cav/mock/client.go
@@ -89,7 +89,7 @@ func NewClient(opts ...OptionFunc) (cav.Client, error) {
 					statusCreated := http.StatusCreated
 					ep.SetMockResponseFunc(func(w http.ResponseWriter, _ *http.Request) {
 						w.WriteHeader(statusCreated)
-						w.Write([]byte(`{"jobId":"87ab1934-0146-4fb0-80bc-815fea03214d","message":"Job created successfully"}`))
+						w.Write([]byte(`{"jobId":"87ab1934-0146-4fb0-80bc-815fea03214d","message":"Job created successfully"}`)) //nolint:errcheck
 					})
 
 				case cav.ClientVmware:
@@ -102,7 +102,7 @@ func NewClient(opts ...OptionFunc) (cav.Client, error) {
 			}
 
 			if ep.MockResponseFuncIsDefined() {
-				log.Default().Printf("Registering mock responseFunc for endpoint %s with method %s", ep.Name, ep.Method)
+				logger.Debug("Registering mock responseFunc for endpoint", slog.String("endpoint", ep.Name), slog.String("method", ep.Method.String()))
 				mux.MethodFunc(ep.Method.String(), buildPath(ep.SubClient, ep.PathTemplate), ep.GetMockResponseFunc())
 				continue
 			}

--- a/cav/subclient_cerberus_jobs.go
+++ b/cav/subclient_cerberus_jobs.go
@@ -18,9 +18,8 @@ import (
 	"github.com/orange-cloudavenue/common-go/validators"
 	"resty.dev/v3"
 
-	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
-
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 )
 
 func init() {

--- a/cav/subclient_cerberus_jobs.go
+++ b/cav/subclient_cerberus_jobs.go
@@ -1,0 +1,198 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package cav
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/orange-cloudavenue/common-go/validators"
+	"resty.dev/v3"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
+)
+
+func init() {
+	Endpoint{
+		Name:             "JobCerberus",
+		Method:           MethodGET,
+		SubClient:        ClientCerberus,
+		DocumentationURL: "https://swagger.cloudavenue.orange-business.com/#/Jobs/getJobById",
+		PathTemplate:     "/api/customers/v1.0/jobs/{taskId}",
+		PathParams: []PathParam{
+			{
+				Name:        "taskId",
+				Description: "The identifier of the task to retrieve.",
+				Required:    true,
+				ValidatorFunc: func(value string) error {
+					return validators.New().Var(value, "required,uuid4")
+				},
+			},
+		},
+		QueryParams: []QueryParam{},
+		RequestFunc: nil, // Will be set later in the Register function.
+		requestInternalFunc: func(ctx context.Context, client *resty.Client, endpoint *Endpoint, opts ...EndpointRequestOption) (*resty.Response, error) {
+			r := client.R().
+				SetContext(ctx).
+				SetHeader("Accept", "application/json;version="+cerberusVCDVersion)
+
+			for _, opt := range opts {
+				if err := opt(endpoint, r); err != nil {
+					return nil, err
+				}
+			}
+
+			return r.Get(endpoint.PathTemplate)
+		},
+		BodyRequestType:  nil, // No request body for this endpoint.
+		BodyResponseType: cerberusJobAPIResponse{},
+	}.Register()
+}
+
+// Ensure cerberus implements the jobs interface.
+var _ jobsInterface = &cerberus{}
+
+// cerberusJobCreatedAPIResponse represents the response body when a job is created
+type cerberusJobCreatedAPIResponse struct {
+	ID      string `json:"jobId" faker:"uuid_hyphenated"`
+	Message string `json:"message" faker:"sentence"`
+}
+
+// cerberusJobAPIResponse represents an asynchronous operation in VCD.
+type cerberusJobAPIResponse []struct {
+	Actions []struct {
+		Name    string `json:"name" faker:"word"`
+		Status  string `json:"status" faker:"oneof:DONE"`
+		Details string `json:"details" faker:"sentence"`
+	} `json:"actions" faker:"slice_len=2"`
+	Description string `json:"description" faker:"sentence"`
+	Name        string `json:"name" faker:"word"`
+	Status      string `json:"status" faker:"oneof:DONE"` // Status of the job.
+}
+
+// JobRefresh is a function type that defines how to refresh a job status.
+func (v *cerberus) JobRefresh(httpC *resty.Client, resp *resty.Response, reqOpts []EndpointRequestOption) (job *Job, err error) {
+	job, err = v.JobParser(resp)
+	if err != nil {
+		return job, err
+	}
+
+	ep, err := GetEndpoint("JobCerberus", MethodGET)
+	if err != nil {
+		return nil, errors.New("failed to get endpoint for JobCerberus: " + err.Error())
+	}
+
+	reqOpts = append(reqOpts,
+		SetCustomRestyOption(func(r *resty.Request) { r.SetError(&cerberusError{}) }),
+		WithPathParam(ep.PathParams[0], urn.ExtractUUID(job.ID)),
+		OverrideSetResult(cerberusJobAPIResponse{}),
+	)
+
+	respR, err := ep.requestInternalFunc(resp.Request.Context(), httpC, ep, reqOpts...)
+	if err != nil {
+		return nil, errors.New("failed to refresh job status: " + err.Error())
+	}
+
+	return v.JobParser(respR)
+}
+
+// JobParser parses the job response body and extracts the job information.
+func (v *cerberus) JobParser(resp *resty.Response) (job *Job, err error) {
+	if resp == nil {
+		return job, errors.New("no response to parse")
+	}
+
+	// The created job have different response structure
+	// Cerberus does not respect the API convention for job creation.
+	// It returns a HTTP 201 status code with a different response body.
+	//
+	// ! This is untestable because resp.Bytes() is indefinable in the mock.
+	if resp.StatusCode() == http.StatusCreated {
+		jobCreated := &cerberusJobCreatedAPIResponse{}
+		if err := json.Unmarshal(resp.Bytes(), jobCreated); err == nil {
+			// Continue only if the unmarshalling was successful.
+			return &Job{
+				ID:          jobCreated.ID,
+				Description: jobCreated.Message,
+			}, nil
+		}
+	}
+
+	if apiR, ok := resp.Result().(*cerberusJobAPIResponse); ok {
+		if len(*apiR) == 0 {
+			return nil, &errors.APIError{
+				StatusCode:    resp.StatusCode(),
+				StatusMessage: "No job returned",
+				Operation:     "Fetching job status",
+				Message:       "The job response is empty",
+				Duration:      resp.Duration(),
+				Endpoint:      resp.Request.URL,
+			}
+		}
+
+		job = &Job{
+			// The taskId is used as the job ID.
+			ID:          resp.Request.PathParams["taskId"],
+			Name:        (*apiR)[0].Name,
+			Description: (*apiR)[0].Description,
+			HREF:        resp.Request.URL,
+		}
+
+		status, err := v.JobStatusParser((*apiR)[0].Status)
+		if err != nil {
+			return nil, errors.New("failed to parse job status: " + err.Error())
+		}
+
+		job.Status = status
+
+		if (*apiR)[0].Status == "FAILED" {
+			return job, &errors.APIError{
+				StatusCode:    resp.StatusCode(),
+				StatusMessage: status.String(),
+				Operation:     "Fetching job status",
+				Message:       (*apiR)[0].Description,
+				Duration:      resp.Duration(),
+				Endpoint:      resp.Request.URL,
+			}
+		}
+
+		return job, nil
+	}
+
+	if err := v.ParseAPIError("JobParser", resp); err != nil {
+		return nil, err
+	}
+
+	return nil, errors.New("failed to parse cerberus job response, unexpected type or empty response")
+}
+
+// Status returns the job status from the response body.
+func (v *cerberus) JobStatusParser(status string) (s JobStatus, err error) {
+	// CREATED, PENDING, IN_PROGRESS, FAILED, DONE
+	switch strings.ToLower(status) {
+	case "created":
+		s = JobQueued
+	case "pending":
+		s = JobQueued
+	case "in_progress":
+		s = JobRunning
+	case "failed":
+		s = JobError
+	case "done":
+		s = JobSuccess
+	default:
+		return "", errors.New("unknown job status: " + status)
+	}
+	return s, nil
+}

--- a/cav/subclient_cerberus_jobs_test.go
+++ b/cav/subclient_cerberus_jobs_test.go
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
 package cav
 
 import (

--- a/cav/subclient_cerberus_jobs_test.go
+++ b/cav/subclient_cerberus_jobs_test.go
@@ -1,0 +1,189 @@
+package cav
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"resty.dev/v3"
+)
+
+func TestCerberusJobStatusParser(t *testing.T) {
+	v := &cerberus{}
+	tests := []struct {
+		input    string
+		expected JobStatus
+		wantErr  bool
+	}{
+		{"created", JobQueued, false},
+		{"pending", JobQueued, false},
+		{"in_progress", JobRunning, false},
+		{"failed", JobError, false},
+		{"done", JobSuccess, false},
+		{"unknown", JobStatus(""), true},
+	}
+	for _, tt := range tests {
+		got, err := v.JobStatusParser(tt.input)
+		if tt.wantErr {
+			assert.Error(t, err, tt.input)
+		} else {
+			assert.NoError(t, err, tt.input)
+			assert.Equal(t, tt.expected, got, tt.input)
+		}
+	}
+}
+
+// * This test is commented out because it requires a specific response structure that is not mockable.
+// Due to resty.Bytes() being undefined in the mock
+//
+// func TestCerberusJobParser_201Created(t *testing.T) {
+// 	v := &cerberus{}
+// 	resp := &resty.Response{
+// 		RawResponse: &http.Response{
+// 			StatusCode: http.StatusCreated,
+// 		},
+// 		Request: &resty.Request{
+// 			PathParams: map[string]string{"taskId": "d3c42a20-96b9-4452-91dd-f71b71dfe314"},
+// 			URL:        "http://example.com/job",
+// 			Result:     &cerberusJobCreatedAPIResponse{ID: "d3c42a20-96b9-4452-91dd-f71b71dfe314", Message: "Job created successfully"},
+// 		},
+// 	}
+// 	job, err := v.JobParser(resp)
+//
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, "d3c42a20-96b9-4452-91dd-f71b71dfe314", job.ID)
+// 	assert.Equal(t, "Job created successfully", job.Description)
+// 	assert.Equal(t, JobQueued, job.Status)
+// }
+
+func TestCerberusJobParser_NormalResponse(t *testing.T) {
+	v := &cerberus{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result: &cerberusJobAPIResponse{
+				{
+					Name:        "test-job",
+					Description: "desc",
+					Status:      "done",
+				},
+			},
+		},
+	}
+	job, err := v.JobParser(resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "id-123", job.ID)
+	assert.Equal(t, "test-job", job.Name)
+	assert.Equal(t, "desc", job.Description)
+	assert.Equal(t, "http://example.com/job", job.HREF)
+	assert.Equal(t, JobSuccess, job.Status)
+}
+
+func TestCerberusJobParser_FailedStatus(t *testing.T) {
+	v := &cerberus{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result: &cerberusJobAPIResponse{
+				{
+					Name:        "test-job",
+					Description: "desc",
+					Status:      "FAILED",
+				},
+			},
+		},
+	}
+	job, err := v.JobParser(resp)
+
+	assert.Error(t, err)
+	assert.NotNil(t, job)
+}
+
+func TestCerberusJobParser_EmptyResponse(t *testing.T) {
+	v := &cerberus{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result:     &cerberusJobAPIResponse{},
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestCerberusJobParser_NilResponse(t *testing.T) {
+	v := &cerberus{}
+	job, err := v.JobParser(nil)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestCerberusJobParser_UnknownJobStatus(t *testing.T) {
+	v := &cerberus{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result: &cerberusJobAPIResponse{
+				{
+					Name:        "test-job",
+					Description: "desc",
+					Status:      "unknown_status",
+				},
+			},
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestCerberusJobParser_CerberusErrorResponse(t *testing.T) {
+	v := &cerberus{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusInternalServerError,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestCerberusJobParser_InvalidResponseType(t *testing.T) {
+	v := &cerberus{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result:     "invalid response type",
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}

--- a/cav/subclient_vmware_jobs.go
+++ b/cav/subclient_vmware_jobs.go
@@ -16,9 +16,8 @@ import (
 	"github.com/orange-cloudavenue/common-go/validators"
 	"resty.dev/v3"
 
-	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
-
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go/pkg/urn"
 )
 
 func init() {

--- a/cav/subclient_vmware_jobs_test.go
+++ b/cav/subclient_vmware_jobs_test.go
@@ -1,0 +1,195 @@
+package cav
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/go-faker/faker/v4"
+	"github.com/stretchr/testify/assert"
+	"resty.dev/v3"
+)
+
+func TestVmwareJobStatusParser(t *testing.T) {
+	v := &vmware{}
+	tests := []struct {
+		input    string
+		expected JobStatus
+		wantErr  bool
+	}{
+		{"queued", JobQueued, false},
+		{"preRunning", JobRunning, false},
+		{"running", JobRunning, false},
+		{"error", JobError, false},
+		{"success", JobSuccess, false},
+		{"aborted", JobAborted, false},
+		{"unknown", JobStatus(""), true},
+	}
+	for _, tt := range tests {
+		got, err := v.JobStatusParser(tt.input)
+		if tt.wantErr {
+			assert.Error(t, err, tt.input)
+		} else {
+			assert.NoError(t, err, tt.input)
+			assert.Equal(t, tt.expected, got, tt.input)
+		}
+	}
+}
+
+func TestVmwareJobParser_201Created(t *testing.T) {
+	v := &vmware{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusCreated,
+			Header: http.Header{
+				"Location": []string{"/api/task/d3c42a20-96b9-4452-91dd-f71b71dfe314"},
+			},
+		},
+	}
+	job, err := v.JobParser(resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "d3c42a20-96b9-4452-91dd-f71b71dfe314", job.ID)
+}
+
+func TestVmwareJobParser_201Created_BadLocationHeader(t *testing.T) {
+	v := &vmware{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusCreated,
+			Header: http.Header{
+				"Location": []string{"invalid-location"},
+			},
+		},
+	}
+	job, err := v.JobParser(resp)
+
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestVmwareJobParser_NormalResponse(t *testing.T) {
+	v := &vmware{}
+
+	data := &vmwareJobAPIResponse{}
+	_ = faker.FakeData(data)
+
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": data.ID},
+			URL:        "http://example.com/job",
+			Result:     data,
+		},
+	}
+	job, err := v.JobParser(resp)
+
+	assert.NoError(t, err)
+	assert.Equal(t, data.ID, job.ID)
+	assert.Equal(t, data.Name, job.Name)
+	assert.Equal(t, data.Description, job.Description)
+	assert.Equal(t, data.HREF, job.HREF)
+	assert.Equal(t, JobSuccess, job.Status)
+}
+
+func TestVmwareJobParser_FailedStatus(t *testing.T) {
+	v := &vmware{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result: &vmwareJobAPIResponse{
+				Status: "error",
+				Error: &vmwareError{
+					StatusCode:    http.StatusInternalServerError,
+					StatusMessage: "Internal Server Error",
+					Message:       "An error occurred while processing the job",
+				},
+			},
+		},
+	}
+	job, err := v.JobParser(resp)
+
+	assert.Error(t, err)
+	assert.NotNil(t, job)
+}
+
+func TestVmwareJobParser_EmptyResponse(t *testing.T) {
+	v := &vmware{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result:     &vmwareJobAPIResponse{},
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestVmwareJobParser_NilResponse(t *testing.T) {
+	v := &vmware{}
+	job, err := v.JobParser(nil)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestVmwareJobParser_UnknownJobStatus(t *testing.T) {
+	v := &vmware{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result: &vmwareJobAPIResponse{
+				Status: "unknown_status",
+			},
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestVmwareJobParser_VmwareErrorResponse(t *testing.T) {
+	v := &vmware{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusInternalServerError,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}
+
+func TestVmwareJobParser_InvalidResponseType(t *testing.T) {
+	v := &vmware{}
+	resp := &resty.Response{
+		RawResponse: &http.Response{
+			StatusCode: http.StatusOK,
+		},
+		Request: &resty.Request{
+			PathParams: map[string]string{"taskId": "id-123"},
+			URL:        "http://example.com/job",
+			Result:     "invalid response type",
+		},
+	}
+	job, err := v.JobParser(resp)
+	assert.Error(t, err)
+	assert.Nil(t, job)
+}

--- a/cav/subclient_vmware_jobs_test.go
+++ b/cav/subclient_vmware_jobs_test.go
@@ -1,3 +1,12 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
 package cav
 
 import (

--- a/internal/httpClient/client.go
+++ b/internal/httpClient/client.go
@@ -18,5 +18,5 @@ func NewHTTPClient() *resty.Client {
 		SetLogger(logger()).
 		SetHeader("User-Agent", "GoCloudAvenueSDK/2.0").
 		SetResponseBodyUnlimitedReads(true).
-		SetDebug(true)
+		SetDebug(false)
 }

--- a/internal/httpClient/client.go
+++ b/internal/httpClient/client.go
@@ -14,5 +14,9 @@ import (
 )
 
 func NewHTTPClient() *resty.Client {
-	return resty.New().SetHeader("User-Agent", "GoCloudAvenueSDK/2.0").SetLogger(logger())
+	return resty.New().
+		SetLogger(logger()).
+		SetHeader("User-Agent", "GoCloudAvenueSDK/2.0").
+		SetResponseBodyUnlimitedReads(true).
+		SetDebug(true)
 }

--- a/pkg/consoles/consoles.go
+++ b/pkg/consoles/consoles.go
@@ -74,7 +74,7 @@ var consoles = map[Console]console{
 			},
 			APICerberus: Service{
 				Enabled:  true,
-				Endpoint: "https://console1.cloudavenue.orange-business.com/api/customers",
+				Endpoint: "https://console1.cloudavenue.orange-business.com",
 			},
 			S3: Service{
 				Enabled:  true,
@@ -102,7 +102,7 @@ var consoles = map[Console]console{
 			},
 			APICerberus: Service{
 				Enabled:  true,
-				Endpoint: "https://console2.cloudavenue.orange-business.com/api/customers",
+				Endpoint: "https://console2.cloudavenue.orange-business.com",
 			},
 			S3: Service{
 				Enabled:  true,
@@ -131,7 +131,7 @@ var consoles = map[Console]console{
 			},
 			APICerberus: Service{
 				Enabled:  true,
-				Endpoint: "https://console4.cloudavenue.orange-business.com/api/customers",
+				Endpoint: "https://console4.cloudavenue.orange-business.com",
 			},
 			Netbackup: Service{
 				Enabled:  true,
@@ -155,7 +155,7 @@ var consoles = map[Console]console{
 			},
 			APICerberus: Service{
 				Enabled:  true,
-				Endpoint: "https://console5.cloudavenue-cha.itn.intraorange/api/customers",
+				Endpoint: "https://console5.cloudavenue-cha.itn.intraorange",
 			},
 			Netbackup: Service{
 				Enabled:  true,

--- a/pkg/consoles/consoles_test.go
+++ b/pkg/consoles/consoles_test.go
@@ -168,10 +168,10 @@ func TestConsole_GetAPICerberusEndpoint(t *testing.T) {
 		console  Console
 		expected string
 	}{
-		{Console1, "https://console1.cloudavenue.orange-business.com/api/customers"},
-		{Console2, "https://console2.cloudavenue.orange-business.com/api/customers"},
-		{Console4, "https://console4.cloudavenue.orange-business.com/api/customers"},
-		{Console5, "https://console5.cloudavenue-cha.itn.intraorange/api/customers"},
+		{Console1, "https://console1.cloudavenue.orange-business.com"},
+		{Console2, "https://console2.cloudavenue.orange-business.com"},
+		{Console4, "https://console4.cloudavenue.orange-business.com"},
+		{Console5, "https://console5.cloudavenue-cha.itn.intraorange"},
 		// Console7, Console8, Console9 do not have Cerberus API enabled, so expect an empty string
 		{Console7, ""},
 		{Console8, ""},


### PR DESCRIPTION
This pull request introduces significant updates to the `cav` package, focusing on enhancing job handling for the `Cerberus` and `VMware` subclients, adding middleware functionality, and improving testing coverage. Key changes include the addition of request middleware support, updates to job parsing logic, and the implementation of new unit tests for better validation and error handling.

### Enhancements to job handling:

* [`cav/subclient_cerberus_jobs.go`](diffhunk://#diff-61d4b4c7d5886db749682b4648856df3ed30381b5b71d4d0291ef54e91a44aeaR1-R197): Added support for parsing Cerberus job creation responses and introduced a new endpoint `JobCerberus` for handling job-related operations. Includes logic for refreshing and parsing job statuses, with detailed error handling for unexpected or failed responses.
* [`cav/subclient_vmware_jobs.go`](diffhunk://#diff-e78faa441b99bcbde097a5c7beca05d43f0bf8834b5241d023aced6c0c790a1fR123-R139): Improved VMware job parsing logic to validate job IDs as UUIDs and handle errors when job statuses or IDs fail to parse correctly. [[1]](diffhunk://#diff-e78faa441b99bcbde097a5c7beca05d43f0bf8834b5241d023aced6c0c790a1fR123-R139) [[2]](diffhunk://#diff-e78faa441b99bcbde097a5c7beca05d43f0bf8834b5241d023aced6c0c790a1fL141-R153)

### Middleware functionality:

* [`cav/endpoint.go`](diffhunk://#diff-e4bf7e8aa1fa3f9decec7af9042f5228b41e79c8fcf2ea9c25987e6a86bcf981R84-R88): Introduced `RequestMiddlewares` to allow custom modifications to HTTP requests before they are sent, such as adding headers or query parameters.
* [`cav/client_request.go`](diffhunk://#diff-639a5e20a07700b717644445bc4007774d9eaa19827c7f91ae5950124b9b0b3fR50-R57): Integrated middleware handling into the `NewRequest` method, ensuring middleware functions are applied when defined for an endpoint.

### Testing improvements:

* [`cav/subclient_cerberus_jobs_test.go`](diffhunk://#diff-9170a82e46909a14b3d97a4149ce53192884e3ad825479bd52550000f2b2b858R1-R198): Added comprehensive unit tests for Cerberus job parsing and status handling, covering edge cases like empty responses, unknown statuses, and error scenarios.
* [`cav/subclient_vmware_jobs_test.go`](diffhunk://#diff-44e165e6f6b1f03951b7a16f7f5ab1f69d574b0338a11ed437ce0e4734f5cce5R1-R204): Added unit tests for VMware job parsing, including validation of job IDs, handling of malformed headers, and error responses.

### Removal of unused dependencies:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L8): Removed the `github.com/google/uuid` dependency, likely due to the introduction of a custom UUID validation mechanism in `common-go/validators`.

### Updates to mock clients:

* [`cav/mock/client.go`](diffhunk://#diff-0df7fc81021d1345eadfdafec1e169678d20e3f8161ef2c7c2e449226952fe08R72-R80): Modified mock behavior for `Cerberus` and `VMware` subclients, including handling specific HTTP status codes and registering mock response functions for endpoints. [[1]](diffhunk://#diff-0df7fc81021d1345eadfdafec1e169678d20e3f8161ef2c7c2e449226952fe08R72-R80) [[2]](diffhunk://#diff-0df7fc81021d1345eadfdafec1e169678d20e3f8161ef2c7c2e449226952fe08R89-R95) [[3]](diffhunk://#diff-0df7fc81021d1345eadfdafec1e169678d20e3f8161ef2c7c2e449226952fe08L100-R116)