### PR TITLE
feat: add defaut retry and add retry hooks in endpoint

### DIFF
--- a/cav/client_request.go
+++ b/cav/client_request.go
@@ -12,6 +12,7 @@ package cav
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"resty.dev/v3"
 )
@@ -77,8 +78,14 @@ func (c *client) NewRequest(ctx context.Context, endpoint *Endpoint, _ ...Reques
 	}
 
 	// Create a new request with the context and options.
+	// To know more about retry see https://resty.dev/docs/retry-mechanism/
 	hR := hC.NewRequest().
-		SetContext(ctxv)
+		SetContext(ctxv).
+		EnableRetryDefaultConditions().
+		SetRetryCount(5).
+		SetRetryMaxWaitTime(5 * time.Second).
+		SetRetryWaitTime(500 * time.Millisecond).
+		AddRetryHooks(endpoint.RetryHooksFuncs...)
 
 	return hR, nil
 }

--- a/cav/endpoint.go
+++ b/cav/endpoint.go
@@ -81,6 +81,12 @@ type (
 		// and body content.
 		RequestFunc func(ctx context.Context, client Client, endpoint *Endpoint, opts ...EndpointRequestOption) (*resty.Response, error)
 
+		// RetryHooksFuncs is a list of functions that can be used to customize the retry behavior of the request.
+		// These functions can be used to modify the request, such as adding headers or query parameters,
+		// or to handle specific conditions that require a retry.
+		// To know more about retry see https://resty.dev/docs/retry-mechanism/
+		RetryHooksFuncs []resty.RetryHookFunc
+
 		// RequestInternalFunc is a function that takes a client and options and returns a resty.Response and an error.
 		// This function is used to make the actual HTTP request (from internal package) to the endpoint.
 		// It allows for customization of the request, such as setting headers, query parameters,


### PR DESCRIPTION
This pull request introduces improvements to the retry mechanism for HTTP requests in the `cav` package. The changes enhance the flexibility and reliability of client requests by adding retry capabilities and hooks for customization.

Enhancements to retry mechanism:

* [`cav/client_request.go`](diffhunk://#diff-639a5e20a07700b717644445bc4007774d9eaa19827c7f91ae5950124b9b0b3fL81-R87): Added retry configuration to the `NewRequest` method, including default retry conditions, retry count, maximum wait time, wait time between retries, and support for custom retry hooks.
* [`cav/client_request.go`](diffhunk://#diff-639a5e20a07700b717644445bc4007774d9eaa19827c7f91ae5950124b9b0b3fR15): Imported the `time` package to support the new retry configurations.

Customization options for retry behavior:

* [`cav/endpoint.go`](diffhunk://#diff-e4bf7e8aa1fa3f9decec7af9042f5228b41e79c8fcf2ea9c25987e6a86bcf981R84-R88): Introduced `RetryHooksFuncs` in the `Endpoint` type, allowing users to define custom retry hooks to modify requests or handle specific retry conditions.