### PR TITLE
docs: add GUIDLINE & ARCHITECTURE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,87 @@
+
+# CloudAvenue SDK V2 Architecture
+
+This document provides a detailed overview of the project architecture, focusing on the main folders (from most to least important), and explains the design and role of Endpoints and Commands in `/api/`.
+
+---
+
+## 1. Main Folders (Ordered by Importance)
+
+### 1.1 `cav/`
+
+**Core SDK logic.**
+
+- Main entry point for the SDK: manages authentication, configuration, and session lifecycle.
+- Hosts the main `Client` struct, which exposes sub-clients for each CloudAvenue service (e.g., VMware, Cerberus, Netbackup).
+- Handles endpoint discovery, service routing, and credential management.
+- Contains sub-client implementations and shared logic for all services.
+
+### 1.2 `api/`
+
+**CloudAvenue API implementations.**
+
+- Organized by functional domain (e.g., `edgegateway/`, `vdc/`, `vdcgroup/`).
+- Each subdirectory exposes high-level methods for interacting with a specific API group.
+- Defines API types (requests, responses, models, params) and main `Client` for each group.
+- Implements endpoint logic and command registration for each resource.
+
+### 1.3 `types/`
+
+**User-facing domain models and parameter types.**
+
+- Contains all exported types exposed to SDK users (e.g., `ModelEdgeGateway`, `ParamsEdgeGateway`).
+- Used for input/output in public SDK methods.
+
+### 1.4 `internal/`
+
+**Internal helpers and implementation details.**
+
+- Contains non-exported logic, utilities, and shared code not exposed to SDK users.
+- Includes `itypes/` for internal API types (e.g., `ApiResponseEdgeGateway`, `ApiRequestEdgeGateway`).
+
+### 1.5 `cmd/`
+
+**Command-line interface and generators.**
+
+- Hosts CLI tools, code generators, and developer utilities.
+- Used for development, testing, and automation.
+
+### 1.6 `pkg/`
+
+**Shared packages.**
+
+- Contains reusable libraries, helpers, and utilities used across the SDK.
+
+### 1.7 `ruleguard/`
+
+**Custom lint rules.**
+
+- Contains ruleguard scripts enforcing naming conventions and best practices.
+
+---
+
+## 2. Endpoint and Commands in `/api/`
+
+### 2.1 Endpoint Design
+
+- Each API group (e.g., `edgegateway`, `vdc`) defines endpoints as Go functions or methods that map to CloudAvenue REST API operations.
+- Endpoints are responsible for:
+ 	- Building and sending HTTP requests.
+ 	- Parsing and validating responses.
+ 	- Mapping internal types (`ApiRequest*`, `ApiResponse*`) to user-facing models (`Model*`).
+- Endpoints are registered and managed by the main `Client` of each API group.
+- Endpoint logic is isolated per resource, making it easy to extend or maintain.
+
+### 2.2 Commands Design
+
+- Commands represent high-level operations exposed to SDK users (e.g., `GetEdgeGateway`, `CreateVDC`).
+- Each command is implemented as a public method on the API group's `Client` struct.
+- Commands:
+ 	- Accept user-supplied parameters (`Params*`).
+ 	- Internally call the appropriate endpoint function.
+ 	- Return user-facing models (`Model*`) or error.
+- Commands are documented and validated by custom linters to ensure naming and usage consistency.
+
+---
+
+For more details, see the [CONTRIBUTING.md](./CONTRIBUTING.md) and [GUIDELINE.md](./GUIDELINE.md) files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to this project! Please read the fol
 
 ---
 
-## 1. Prerequisites
+## Prerequisites
 
 - **Go Version**: This project requires **Go 1.24** or higher.  
   Check your version with:
@@ -21,92 +21,38 @@ Thank you for your interest in contributing to this project! Please read the fol
 
 ---
 
-## 2. Project Architecture
+## Best Practices
 
-The project is organized into several main directories:
+- **Commit Convention**:  
+  Use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format for your commit messages (e.g., `feat: add multi-tenant support`, `fix: authentication bug fix`).
 
-- **`cav/`**  
-  Contains the core SDK logic: main client management, authentication, sub-clients (Vmware, Cerberus, S3, etc.), endpoint management, and more.
+- **Unit Tests**:  
+  Every new feature or bug fix must be covered by unit tests.  
+  Run tests with:
 
-- **`api/`**  
-  Contains CloudAvenue API implementations, organized by functional domain (e.g., `org/v1/`, etc).  
-  Each subdirectory exposes high-level methods to interact with the various services.
+  ```sh
+  go test ./...
+  ```
 
-> More detailed sections about the `cav` and `api` architecture will be provided later in this document.
+- **Linting**:  
+  The project uses [golangci-lint](https://golangci-lint.run/).  
+  Check linting before submitting a PR:
+
+  ```sh
+  golangci-lint run
+  ```
+
+- **Respect GitHub Workflows**:  
+  PRs are automatically validated (lint, tests, license, etc).  
+  Make sure all checks pass before requesting a review.
+
+- **Documentation**:  
+  Document your public functions and add usage examples if necessary.
 
 ---
 
-## 2.1 The `cav` Client
-
-The `cav` package is the core entry point of the SDK. It is responsible for:
-
-- Managing authentication and configuration for CloudAvenue services.
-- Providing a unified client (`client`) that exposes access to various sub-clients (e.g., VMware, Cerberus, Netbackup).
-- Handling endpoint discovery and service routing.
-- Managing session lifecycle and credentials.
-
-#### General Workflow
-
-1. **Initialization**:  
-   The user creates a new `client` by providing credentials and configuration options.
-
-2. **Authentication**:  
-   The client authenticates with CloudAvenue and manages tokens or session information.
-
-3. **Sub-client Access**:  
-   The `client` exposes sub-clients for specific services (e.g., VMware, Cerberus, Netbackup). Each sub-client is initialized with the necessary context and endpoints.
-
-4. **Service Operations**:  
-   Users interact with the sub-clients to perform operations on CloudAvenue resources.
-
-#### Mermaid Diagram
-
-```mermaid
-classDiagram
-    class client {
-        -resty.Client httpClient
-        -consoles.Console console
-        -map[SubClientName]SubClient clientsInitialized
-        +NewRequest()
-        +ParseAPIError()
-    }
-    class SubClient {
-        <<interface>>
-    }
-    class subclient {
-        -resty.Client httpClient
-        -auth credential
-    }
-    class vmware {
-        subclient
-        +ParseAPIError()
-    }
-    class cerberus {
-        subclient
-        +ParseAPIError()
-    }
-    class auth {
-        <<interface>>
-    }
-    class cloudavenueCredential {
-        +username
-        +password
-        +organization
-        +bearer
-    }
-
-    client o-- "1" consoles.Console
-    client o-- "1" resty.Client
-    client o-- "*" SubClient
-    SubClient <|.. vmware
-    SubClient <|.. cerberus
-    vmware --|> subclient
-    cerberus --|> subclient
-    subclient o-- "1" resty.Client
-    subclient o-- "1" auth
-    auth <|.. cloudavenueCredential
-```
-
+Thank you for following these guidelines to help ensure the quality and maintainability of the CloudAvenue SDK. We appreciate your contributions!
+  
 This diagram reflects the actual dependencies and composition in the [`cav`](cav) package:  
 
 - The main `client` holds a `resty.Client`, a `consoles.Console`, and a map of initialized sub-clients.
@@ -129,6 +75,7 @@ The `api/` directory contains all the APIs consumed by the SDK, organized by maj
 ### Example Structure
 
 ```
+
 api/
   edgegateway/
     v1/
@@ -141,6 +88,7 @@ api/
   vapp/
     v1/
       vapp.go
+
 ```
 
 This approach allows the SDK to evolve and support multiple API versions for each object group, ensuring stability for users even as the underlying APIs change.
@@ -172,42 +120,6 @@ This approach allows the SDK to evolve and support multiple API versions for eac
 
 - **Documentation**:  
   Document your public functions and add usage examples if necessary.
-
----
-
-## 4. Lint Rules and Naming Conventions
-
-To maintain code quality and consistency, the following lint rules are enforced in this project.  
-These rules are checked automatically by custom linters and ruleguard scripts.
-
-### API Type Naming
-
-- **API Response Types:**  
-  Must be named `apiResponse<Object>` (e.g., `apiResponseEdgeGateway`).
-- **API Request Body Types:**  
-  Must be named `apiRequest<Object>` (e.g., `apiRequestEdgeGateway`).
-- **User-facing Model Types:**  
-  Must be named `Model<Object>` (e.g., `ModelEdgeGateway`).
-- **User-supplied Parameter Types:**  
-  Must be named `Params<Object>` (e.g., `ParamsEdgeGateway`).
-- **Client Types:**  
-  Must be named `Client` (exactly, for the main client struct of an API group).
-
-You can visualize and debug the naming convention regex used by the linter here: [https://regex101.com/r/g8Av6t/1](https://regex101.com/r/g8Av6t/1)
-
-### API Function Naming
-
-- Exported functions in any `api/` directory must start with one of the following prefixes:  
-  `Get`, `Create`, `List`, `Delete`, `Update`, `Enable`, `Disable`, `Add`, `Remove`
-  - Example: `GetEdgeGateway`, `CreateVDC`, `ListVApps`
-- Functions returning a boolean value must start with:  
-  `Is`, `is`, `Has`, `has`, `Match`, `match`
-  - Example: `IsEnabled`, `HasPermission`, `matchURN`
-
-### ToModel Method Rule
-
-- Exported `ToModel` methods are **not allowed** on types named `apiResponse*` or `apiRequest*` in any `api/` directory.
-- Use a private `toModel` method instead to avoid exposing internal conversion logic.
 
 ---
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -1,0 +1,97 @@
+# CloudAvenue SDK V2 Guidelines
+
+This document describes the coding standards, lint rules, naming conventions, and best practices for contributing to the CloudAvenue SDK V2 project.
+
+---
+
+## Coding Standards
+
+- **Idiomatic Go**: Follow [Effective Go](https://go.dev/doc/effective_go) and [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments).
+- **Documentation**: All exported functions, types, and packages must have clear GoDoc comments.
+- **Error Handling**: Use wrapped errors with context. Prefer `fmt.Errorf("...: %w", err)`.
+- **Testing**: Write table-driven tests. Use subtests for complex scenarios.
+- **Concurrency**: Use sync primitives (e.g., `sync.Mutex`) carefully. Avoid global state.
+
+---
+
+## Lint Rules and Naming Conventions
+
+To maintain code quality and consistency, the following lint rules are enforced in this project.  
+These rules are checked automatically by custom linters and ruleguard scripts.
+
+### API Type Naming
+
+- **API Response Types**  
+  - Format: `ApiResponse<Object>` (e.g., `ApiResponseEdgeGateway`).
+  - Used for types representing API responses from CloudAvenue endpoints.
+  - Location: `internal/itypes/`
+  - **Note:** These types are for internal use only and must not be exposed to SDK users.
+
+- **API Request Body Types**  
+  - Format: `ApiRequest<Object>` (e.g., `ApiRequestEdgeGateway`).
+  - Used for types representing request bodies sent to CloudAvenue endpoints.
+  - Location: `internal/itypes/`
+  - **Note:** These types are for internal use only and must not be exposed to SDK users.
+
+- **User-facing Model Types**  
+  - Format: `Model<Object>` (e.g., `ModelEdgeGateway`).
+  - Used for types exposed to SDK users, representing domain models.
+  - Location: `types/`
+
+- **User-supplied Parameter Types**  
+  - Format: `Params<Object>` (e.g., `ParamsEdgeGateway`).
+  - Used for types representing parameters supplied by users to SDK methods.
+  - Location: `types/`
+
+- **Client Types**  
+  - Name: `Client` (exactly, for the main client struct of an API group).
+  - Used for the main client struct managing API group operations.
+  - Location: `api/<group>/` or `cav/`
+
+> You can visualize and debug the naming convention regex used by the linter here: [https://regex101.com/r/g8Av6t/1](https://regex101.com/r/g8Av6t/1)
+
+### API Function Naming
+
+- Exported functions in any `api/` directory must start with one of the following prefixes:  
+  `Get`, `Create`, `List`, `Delete`, `Update`, `Enable`, `Disable`, `Add`, `Remove`
+  - Example: `GetEdgeGateway`, `CreateVDC`, `ListVApps`
+- Functions returning a boolean value must start with:  
+  `Is`, `is`, `Has`, `has`, `Match`, `match`
+  - Example: `IsEnabled`, `HasPermission`, `matchURN`
+
+**Details of names of exported functions in `api/` directories :**
+
+- `List` functions should return a list of objects. No error returned if the list is empty.
+- `Get` functions should return a single object. Return an error if not found.
+- `Create` functions create a new object and return it.
+- `Update` functions update the specified object and return it.
+- `Delete` functions delete the specified object.
+- `Enable` functions enable the specified object. Only errors are returned.
+- `Disable` functions disable the specified object. Only errors are returned.
+- `Add` functions add a new object. Only errors are returned.
+- `Remove` functions remove the specified object. Only errors are returned.
+
+---
+
+## Naming Conventions
+
+- **Packages**: Use short, meaningful, lowercase names (e.g., `client`, `api`, `utils`).
+- **Files**: Use snake_case for file names (e.g., `auth.go`, `client_options.go`).
+- **Types**: Use PascalCase for exported types (e.g., `CloudAvenueClient`).
+- **Functions**: Use camelCase for unexported, PascalCase for exported.
+- **Variables**: Use short, descriptive names. Avoid abbreviations unless well-known.
+- **Constants**: Use ALL_CAPS or PascalCase for exported constants.
+
+---
+
+## Pull Request Checklist
+
+- [ ] Code is formatted (`gofmt`)
+- [ ] Lint checks pass
+- [ ] Unit tests added/updated
+- [ ] Documentation updated
+- [ ] PR description is clear and references related issues
+
+---
+
+For more details, see the [CONTRIBUTING.md](./CONTRIBUTING.md) and [ARCHITECTURE.md](./ARCHITECTURE.md) files.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It provides authentication, client configuration, and helpers to access CloudAve
 
 ## Example Usage
 
-Below is a minimal example showing how to initialize a CloudAvenue SDK client and perform a simple request using the `org` API:
+Below is a minimal example showing how to initialize a CloudAvenue SDK client and perform a simple request using the `vdc` client:
 
 ```go
 package main
@@ -17,8 +17,9 @@ import (
     "context"
     "fmt"
 
-    "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/api/org/v1"
+    "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/api/vdc/v1"
     "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav"
+    "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
 )
 
 func main() {
@@ -33,22 +34,38 @@ func main() {
         fmt.Println("Error creating client:", err)
         return
     }
+    defer client.Close()
 
-    // Create an org API client
-    orgClient, err := org.New(client)
+    // Create an VDC client
+    ev, err := vdc.New(client)
     if err != nil {
-        fmt.Println("Error creating org client:", err)
-        return
+      fmt.Println("Error creating VDC client:", err)
+      return
+    }
+    
+    vdcCreated, err := ev.CreateVDC(ctx, types.ParamsCreateVDC{
+       Name:                "test-vdc",
+       Description:         "Test VDC",
+       ServiceClass:        "ECO",
+       BillingModel:        "PAYG",
+       DisponibilityClass:  "ONE-ROOM",
+       StorageBillingModel: "PAYG",
+       Vcpu:                5,
+       Memory:              50,
+       StorageProfiles: []types.ParamsCreateVDCStorageProfile{
+         {
+            Class:   "silver",
+            Limit:   100,
+            Default: true,
+         },
+       },
+    })
+    if err != nil {
+     fmt.Println("Error creating VDC:", err)
+     return
     }
 
-    // Perform a demo request (replace with your own URN)
-    _, err = orgClient.DemoRequest(ctx, "urn:vcloud:org:9bf2eb9d-78fb-476b-a15a-1f4b7da4d132")
-    if err != nil {
-        fmt.Println("Error making request:", err)
-        return
-    }
-
-    fmt.Println("Request completed successfully")
+    fmt.Printf("VDC created: %+v\n", vdcCreated)
 }
 ```
 
@@ -59,3 +76,11 @@ This project is licensed under the [Mozilla Public License 2.0](LICENSE).
 ---
 
 Orange CloudAvenue
+
+---
+
+## Documentation & Contribution
+
+- [Contribution Guide](./CONTRIBUTING.md)
+- [Coding Guidelines](./GUIDELINE.md)
+- [Project Architecture](./ARCHITECTURE.md)

--- a/ruleguard/rules_api.go
+++ b/ruleguard/rules_api.go
@@ -1,3 +1,6 @@
+//go:build ruleguard
+// +build ruleguard
+
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
  * SPDX-License-Identifier: Mozilla Public License 2.0
@@ -7,37 +10,19 @@
  * or see the "LICENSE" file for more details.
  */
 
-//go:build ruleguard
-// +build ruleguard
-
 package gorules
 
 import (
 	"github.com/quasilyte/go-ruleguard/dsl"
 )
 
-// apiResponseToModel checks for exported ToModel functions in API response/request types.
-// It disallows exported ToModel methods for types named apiResponse* or apiRequest* in any `api/` directory.
-// Instead, it suggests using a private toModel method to prevent exposing internal conversion logic.
-// This helps enforce encapsulation and maintain clean API boundaries.
-func apiResponseToModel(m dsl.Matcher) {
-	m.Match(`func ($recv $recvtype) $f($params) ($output) { $body }`).
-		Where(
-			m.File().PkgPath.Matches(`api/`) &&
-				m["recvtype"].Text.Matches(`^(apiResponse|apiRequest)[A-Za-z0-9_]*$`) &&
-				m["f"].Text.Matches(`^ToModel$`),
-		).
-		Report(`Disallow exported ToModel functions in API response types. Use a private function instead.`).
-		Suggest(`func ($recv $recvtype) toModel$params ($output) { $body }`)
-}
-
 // apiTypes checks for common API types in the codebase.
 // It ensures that the types used in API endpoints are consistent and follow best practices.
 // Ensures that struct types in any `api/` directory follow these naming conventions:
 //   - **API Response Types:**
-//     Must be named `apiResponse<Object>` (e.g., `apiResponseEdgeGateway`).
+//     Must be named `ApiResponse<Object>` (e.g., `ApiResponseEdgeGateway`).
 //   - **API Request Body Types:**
-//     Must be named `apiRequest<Object>` (e.g., `apiRequestEdgeGateway`).
+//     Must be named `ApiRequest<Object>` (e.g., `ApiRequestEdgeGateway`).
 //   - **User-facing Model Types:**
 //     Must be named `Model<Object>` (e.g., `ModelEdgeGateway`).
 //   - **User-supplied Parameter Types:**
@@ -51,8 +36,8 @@ func apiResponseTypes(m dsl.Matcher) {
 	m.Match(
 		`type $name struct { $*_ }`,
 	).
-		Where(m.File().PkgPath.Matches(`api/`) && !m["name"].Text.Matches(`^(apiResponse|apiRequest|Model|Params)[A-Z][A-Za-z0-9]*$|^Client$`)).
-		Report(`Struct type names must start with apiResponse | apiRequest | Model | Params (See CONTRIBUTING.md)`)
+		Where(m.File().PkgPath.Matches(`api/`) && !m["name"].Text.Matches(`^(ApiResponse|ApiRequest|Model|Params)[A-Z][A-Za-z0-9]*$|^Client$`)).
+		Report(`Struct type names must start with ApiResponse | ApiRequest | Model | Params (See GUIDELINE.md)`)
 }
 
 // apiFuncPrefix enforces naming conventions for exported functions in API packages.


### PR DESCRIPTION
This pull request introduces significant improvements to project documentation and enforces stricter naming conventions and lint rules for the CloudAvenue SDK V2. The changes clarify the architecture, coding standards, and contribution workflow, making it easier for contributors to understand the codebase and maintain consistency. The most important updates are grouped below:

**Documentation and Architecture Updates:**

* Added a comprehensive `ARCHITECTURE.md` file describing the SDK’s folder structure, the role of endpoints and commands, and how API groups are organized and implemented.
* Updated the `README.md` example to use the `vdc` client instead of `org`, and added links to contribution, guidelines, and architecture documents for easier navigation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L20-R22) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R37-R68) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79-R86)

**Contribution Guidelines and Best Practices:**

* Refactored `CONTRIBUTING.md` to focus on prerequisites and best practices, moving architecture and lint rules to dedicated documents. Added clear instructions for commit conventions, testing, linting, documentation, and workflow checks. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L7-R7) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L24-R54) [[3]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R78) [[4]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R91) [[5]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L178-L213)
* Created a new `GUIDELINE.md` file detailing coding standards, lint rules, naming conventions, and a PR checklist for contributors.

**Lint Rules and Naming Conventions Enforcement:**

* Updated `ruleguard/rules_api.go` to enforce the new naming conventions (`ApiResponse*`, `ApiRequest*` with PascalCase) and improved error messages to reference the new guidelines. [[1]](diffhunk://#diff-2848de4fe2644f65ea82c8f27c18d1a1f1989c0a88244c958823a10304382f04R1-R3) [[2]](diffhunk://#diff-2848de4fe2644f65ea82c8f27c18d1a1f1989c0a88244c958823a10304382f04L10-R25) [[3]](diffhunk://#diff-2848de4fe2644f65ea82c8f27c18d1a1f1989c0a88244c958823a10304382f04L54-R40)

These changes collectively improve the clarity, maintainability, and consistency of the SDK, making it easier for new and existing contributors to follow best practices and architectural standards.