### PR TITLE
fix: retry if already exist

### DIFF
--- a/cav/client_request.go
+++ b/cav/client_request.go
@@ -146,6 +146,8 @@ func (c *client) NewRequest(ctx context.Context, endpoint *Endpoint, _ ...Reques
 		retryIdempotent = true
 	}
 
+	// ContextData store specific data in the context.
+	// This context is used to pass additional information between middleware and handlers.
 	contextData := ContextData{}
 	switch sc := sc.(type) {
 	case *vmware:
@@ -165,6 +167,8 @@ func (c *client) NewRequest(ctx context.Context, endpoint *Endpoint, _ ...Reques
 		AddRetryConditions(retryConditionsFuncs...).
 		SetAllowNonIdempotentRetry(retryIdempotent)
 
+	// Set the query parameters in the request.
+	// This is done to set the query parameters in the HTTP requests.
 	for _, q := range endpoint.QueryParams {
 		if q.Value != "" {
 			// If a value is provided for the query parameter, use it directly.

--- a/cav/subclient_cerberus_jobs.go
+++ b/cav/subclient_cerberus_jobs.go
@@ -102,9 +102,12 @@ func (v *cerberus) JobRefresh(httpC *resty.Client, resp *resty.Response, reqOpts
 	}
 
 	reqOpts = append(reqOpts,
-		SetCustomRestyOption(func(r *resty.Request) { r.SetError(&cerberusError{}) }),
+		SetCustomRestyOption(
+			func(r *resty.Request) {
+				r.SetError(&cerberusError{})
+				r.SetResult(&CerberusJobAPIResponse{})
+			}),
 		WithPathParam(ep.PathParams[0], urn.ExtractUUID(job.ID)),
-		OverrideSetResult(CerberusJobAPIResponse{}),
 	)
 
 	respR, err := ep.requestInternalFunc(resp.Request.Context(), httpC, ep, reqOpts...)


### PR DESCRIPTION
This pull request introduces improvements to the job handling and retry logic in the Cerberus subclient, making retries more robust and context-aware. The main changes focus on enhancing idempotent retry conditions, refining job middleware to handle busy states, and improving error/result handling for job refresh requests.

**Retry Logic and Middleware Enhancements:**

* Added a new `idempotentRetryCondition()` method to the `jobsInterface`, enabling subclients to define custom retry logic for idempotent operations. This is now used in job middleware to better handle retry scenarios.
* Updated the job middleware in `newJobMiddleware` to apply both the idempotent retry condition and the job status retry condition, improving how retries are managed for job status checks. Also added logic to bypass job middleware if the response matches the idempotent retry condition (e.g., when the job is busy). [[1]](diffhunk://#diff-44afa08b8aca0419039d3b53d4d1e47377dbc7c0be6e5871cd635642110c530bL67-R77) [[2]](diffhunk://#diff-44afa08b8aca0419039d3b53d4d1e47377dbc7c0be6e5871cd635642110c530bR87-R91)

**Cerberus Subclient Improvements:**

* Refined the `idempotentRetryCondition` implementation in the Cerberus subclient to better handle specific error types and messages, ensuring retries only occur when appropriate (e.g., "Job already exists" errors).
* Improved the error and result handling in Cerberus job refresh requests by setting both the error and result types on the Resty request, ensuring more accurate response parsing.

**General Codebase Improvements:**

* Added comments and clarified the use of `ContextData` in `client_request.go` to document how context is used for passing data between middleware and handlers. Also documented the process of setting query parameters in HTTP requests. [[1]](diffhunk://#diff-639a5e20a07700b717644445bc4007774d9eaa19827c7f91ae5950124b9b0b3fR149-R150) [[2]](diffhunk://#diff-639a5e20a07700b717644445bc4007774d9eaa19827c7f91ae5950124b9b0b3fR170-R171)