### PR TITLE
feat: add draas commands

### DIFF
--- a/api/draas/v1/client.go
+++ b/api/draas/v1/client.go
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+package draas
+
+import (
+	"log/slog"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
+)
+
+type (
+	Client struct {
+		c      cav.Client
+		logger *slog.Logger
+	}
+)
+
+// New creates a new draas client.
+func New(c cav.Client) (*Client, error) {
+	if c == nil {
+		return nil, errors.ErrClientNotInitialized
+	}
+
+	logger := c.Logger().WithGroup("draas")
+	logger.Debug("Successfully creating new client")
+
+	return &Client{
+		c:      c,
+		logger: logger,
+	}, nil
+}

--- a/api/draas/v1/client_test.go
+++ b/api/draas/v1/client_test.go
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package draas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewClient_ClientNil(t *testing.T) {
+	c, err := New(nil)
+	assert.Nil(t, c, "Expected nil client when input is nil")
+	assert.Error(t, err, "Expected error when input is nil")
+}

--- a/api/draas/v1/commands.go
+++ b/api/draas/v1/commands.go
@@ -1,0 +1,14 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package draas
+
+import "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/commands"
+
+var cmds = commands.NewRegistry()

--- a/api/draas/v1/draas_commands.go
+++ b/api/draas/v1/draas_commands.go
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package draas
+
+import (
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/commands"
+)
+
+func init() {
+	// * Draas
+	cmds.Register(commands.Command{
+		Namespace: "Draas",
+		Verb:      "",
+	})
+}

--- a/api/draas/v1/draas_on_premise_commands.go
+++ b/api/draas/v1/draas_on_premise_commands.go
@@ -1,0 +1,134 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package draas
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/commands"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/endpoints"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/itypes"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
+)
+
+//go:generate command-generator -path draas_on_premise_commands.go
+
+func init() {
+	// * Draas OnPremise
+	cmds.Register(commands.Command{
+		Namespace: "Draas",
+		Resource:  "OnPremiseIp",
+		Verb:      "",
+	})
+
+	// * ListDraasOnPremise
+	cmds.Register(commands.Command{
+		Namespace:          "Draas",
+		Resource:           "OnPremiseIp",
+		Verb:               "List",
+		ShortDocumentation: "List all OnPremise IPs allowed",
+		LongDocumentation:  "List all OnPremise IPs allowed allowed for this organization's draas offer",
+		AutoGenerate:       true,
+		ModelType:          types.ModelListDraasOnPremise{},
+		RunnerFunc: func(ctx context.Context, cmd *commands.Command, client, params any) (any, error) {
+			cc := client.(*Client)
+
+			ep := endpoints.ListDraasOnPremiseIp()
+
+			resp, err := cc.c.Do(
+				ctx,
+				ep,
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to list Draas OnPremiseIP: %w", err)
+			}
+
+			return resp.Result().(*itypes.ApiResponseListDraasOnPremise).ToModel(), nil
+		},
+	})
+
+	// * AddDraasOnPremiseIp
+	cmds.Register(commands.Command{
+		Namespace:          "Draas",
+		Resource:           "OnPremiseIp",
+		Verb:               "Add",
+		ShortDocumentation: "Add a new OnPremise IP",
+		LongDocumentation:  "Add a new OnPremise IP (only IPV4) address to this organization's draas offer",
+		AutoGenerate:       true,
+		ParamsType:         types.ParamsAddDraasOnPremiseIP{},
+		ParamsSpecs: commands.ParamsSpecs{
+			{
+				Name:        "ip",
+				Required:    true,
+				Description: "Your OnPremise IP address to authorize to the DRaaS offer",
+				Example:     "195.25.13.4",
+				Validators: []commands.Validator{
+					commands.ValidatorIPV4(),
+				},
+			},
+		},
+		RunnerFunc: func(ctx context.Context, cmd *commands.Command, client, params any) (any, error) {
+			cc := client.(*Client)
+			p := params.(types.ParamsAddDraasOnPremiseIP)
+			ep := endpoints.AddDraasOnPremiseIp()
+
+			_, err := cc.c.Do(
+				ctx,
+				ep,
+				cav.WithPathParam(ep.PathParams[0], p.IP),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to add Draas OnPremiseIP: %w", err)
+			}
+
+			return nil, nil
+		},
+	})
+
+	// * RemoveDraasOnPremiseIp
+	cmds.Register(commands.Command{
+		Namespace:          "Draas",
+		Resource:           "OnPremiseIp",
+		Verb:               "Remove",
+		ShortDocumentation: "Remove an existing OnPremise IP",
+		LongDocumentation:  "Remove an existing OnPremise IP address from this organization's draas offer",
+		AutoGenerate:       true,
+		ParamsType:         types.ParamsRemoveDraasOnPremiseIP{},
+		ParamsSpecs: commands.ParamsSpecs{
+			{
+				Name:        "ip",
+				Required:    true,
+				Description: "Your OnPremise IP address to remove from the DRaaS offer",
+				Example:     "195.25.13.4",
+				Validators: []commands.Validator{
+					commands.ValidatorIPV4(),
+				},
+			},
+		},
+		RunnerFunc: func(ctx context.Context, cmd *commands.Command, client, params any) (any, error) {
+			cc := client.(*Client)
+			p := params.(types.ParamsRemoveDraasOnPremiseIP)
+			ep := endpoints.RemoveDraasOnPremiseIp()
+
+			_, err := cc.c.Do(
+				ctx,
+				ep,
+				cav.WithPathParam(ep.PathParams[0], p.IP),
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to remove Draas OnPremiseIP: %w", err)
+			}
+
+			return nil, nil
+		},
+	})
+}

--- a/api/draas/v1/draas_on_premise_test.go
+++ b/api/draas/v1/draas_on_premise_test.go
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package draas
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/endpoints"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
+	"github.com/orange-cloudavenue/common-go/generator"
+	"github.com/orange-cloudavenue/common-go/validators"
+)
+
+func TestListDraasOnPremiseIP(t *testing.T) {
+	tests := []struct {
+		name               string
+		mockResponseStatus int
+		mockResponse       any
+		expectedErr        bool
+	}{
+		{
+			name:        "ListDraasOnPremiseIP OK",
+			expectedErr: false,
+		},
+		{
+			name:               "ListDraasOnPremiseIP Not Found",
+			mockResponseStatus: http.StatusNotFound,
+			mockResponse:       nil,
+			expectedErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mockResponseStatus != 0 {
+				endpoints.ListDraasOnPremiseIp().CleanMockResponse()
+				endpoints.ListDraasOnPremiseIp().SetMockResponse(tt.mockResponse, &tt.mockResponseStatus)
+			}
+
+			client := newClient(t)
+
+			resp, err := client.ListOnPremiseIp(t.Context())
+			if tt.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err, "Unexpected error: %v", err)
+			assert.NotNil(t, resp, "Response should not be nil")
+			assert.NotEmpty(t, resp.IPs, "OnPremise IPs should not be empty")
+			for _, ip := range resp.IPs {
+				assert.NoError(t, validators.New().Var(ip, "required,ipv4"))
+			}
+		})
+	}
+}
+
+func TestAddDraasOnPremiseIP(t *testing.T) {
+	tests := []struct {
+		name               string
+		params             types.ParamsAddDraasOnPremiseIP
+		mockResponseStatus int
+		mockResponse       any
+		expectedErr        bool
+	}{
+		{
+			name: "AddDraasOnPremiseIP OK",
+			params: types.ParamsAddDraasOnPremiseIP{
+				IP: generator.MustGenerate("{ipv4address}"),
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "No IP params provided",
+			expectedErr: true,
+		},
+		{
+			name: "Invalid IP format",
+			params: types.ParamsAddDraasOnPremiseIP{
+				IP: "invalid-ip",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Bad request",
+			params: types.ParamsAddDraasOnPremiseIP{
+				IP: generator.MustGenerate("{ipv4address}"),
+			},
+			mockResponseStatus: http.StatusBadRequest,
+			expectedErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mockResponseStatus != 0 {
+				endpoints.AddDraasOnPremiseIp().CleanMockResponse()
+				endpoints.AddDraasOnPremiseIp().SetMockResponse(tt.mockResponse, &tt.mockResponseStatus)
+			}
+
+			client := newClient(t)
+
+			err := client.AddOnPremiseIp(t.Context(), tt.params)
+			if tt.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err, "Unexpected error: %v", err)
+		})
+	}
+}
+
+func TestRemoveDraasOnPremiseIP(t *testing.T) {
+	tests := []struct {
+		name               string
+		params             types.ParamsRemoveDraasOnPremiseIP
+		mockResponseStatus int
+		mockResponse       any
+		expectedErr        bool
+	}{
+		{
+			name: "RemoveDraasOnPremiseIP OK",
+			params: types.ParamsRemoveDraasOnPremiseIP{
+				IP: generator.MustGenerate("{ipv4address}"),
+			},
+			expectedErr: false,
+		},
+		{
+			name:        "No IP params provided",
+			expectedErr: true,
+		},
+		{
+			name: "Invalid IP format",
+			params: types.ParamsRemoveDraasOnPremiseIP{
+				IP: "invalid-ip",
+			},
+			expectedErr: true,
+		},
+		{
+			name: "Bad request",
+			params: types.ParamsRemoveDraasOnPremiseIP{
+				IP: generator.MustGenerate("{ipv4address}"),
+			},
+			mockResponseStatus: http.StatusBadRequest,
+			expectedErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.mockResponseStatus != 0 {
+				endpoints.RemoveDraasOnPremiseIp().CleanMockResponse()
+				endpoints.RemoveDraasOnPremiseIp().SetMockResponse(tt.mockResponse, &tt.mockResponseStatus)
+			}
+
+			client := newClient(t)
+
+			err := client.RemoveOnPremiseIp(t.Context(), tt.params)
+			if tt.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err, "Unexpected error: %v", err)
+		})
+	}
+}

--- a/api/draas/v1/helper_test.go
+++ b/api/draas/v1/helper_test.go
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package draas
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav/mock"
+)
+
+var testMutex = sync.Mutex{}
+
+func newClient(t *testing.T) *Client {
+	t.Helper()
+
+	testMutex.Lock()
+	t.Cleanup(func() {
+		testMutex.Unlock()
+	})
+
+	mC, err := mock.NewClient(
+		mock.WithLogger(
+			slog.New(
+				slog.NewTextHandler(
+					os.Stdout,
+					&slog.HandlerOptions{
+						Level: slog.LevelDebug,
+					}),
+			),
+		),
+	)
+	assert.Nil(t, err, "Error creating mock client")
+
+	eC, err := New(mC)
+	assert.Nil(t, err, "Error creating draas client")
+	return eC
+}

--- a/api/draas/v1/zz_draas_on_premise.go
+++ b/api/draas/v1/zz_draas_on_premise.go
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package draas
+
+import (
+	"context"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
+)
+
+// List all OnPremise IPs allowed for this organization's draas offer
+func (c *Client) ListOnPremiseIp(ctx context.Context) (*types.ModelListDraasOnPremise, error) {
+	x, err := cmds.Get("Draas", "OnPremiseIp", "List").Run(ctx, c, nil)
+	if err != nil {
+		return nil, err
+	}
+	return x.(*types.ModelListDraasOnPremise), nil
+}
+
+// Add a new OnPremise IP address to this organization's draas offer
+func (c *Client) AddOnPremiseIp(ctx context.Context, params types.ParamsAddDraasOnPremiseIP) error {
+	_, err := cmds.Get("Draas", "OnPremiseIp", "Add").Run(ctx, c, params)
+	return err
+}
+
+// Remove an existing OnPremise IP address from this organization's draas offer
+func (c *Client) RemoveOnPremiseIp(ctx context.Context, params types.ParamsRemoveDraasOnPremiseIP) error {
+	_, err := cmds.Get("Draas", "OnPremiseIp", "Remove").Run(ctx, c, params)
+	return err
+}

--- a/api/edgegateway/v1/zz_bandwidth.go
+++ b/api/edgegateway/v1/zz_bandwidth.go
@@ -23,3 +23,4 @@ func (c *Client) GetBandwidth(ctx context.Context, params types.ParamsEdgeGatewa
 	}
 	return x.(*types.ModelEdgeGatewayBandwidth), nil
 }
+

--- a/api/edgegateway/v1/zz_edgegateway.go
+++ b/api/edgegateway/v1/zz_edgegateway.go
@@ -23,7 +23,6 @@ func (c *Client) GetEdgeGateway(ctx context.Context, params types.ParamsEdgeGate
 	}
 	return x.(*types.ModelEdgeGateway), nil
 }
-
 // List EdgeGateways performs a GET request to retrieve a list of edge gateways
 func (c *Client) ListEdgeGateway(ctx context.Context) (*types.ModelEdgeGateways, error) {
 	x, err := cmds.Get("EdgeGateway", "", "List").Run(ctx, c, nil)
@@ -32,7 +31,6 @@ func (c *Client) ListEdgeGateway(ctx context.Context) (*types.ModelEdgeGateways,
 	}
 	return x.(*types.ModelEdgeGateways), nil
 }
-
 // Create EdgeGateway performs a POST request to create a new edge gateway
 func (c *Client) CreateEdgeGateway(ctx context.Context, params types.ParamsCreateEdgeGateway) (*types.ModelEdgeGateway, error) {
 	x, err := cmds.Get("EdgeGateway", "", "Create").Run(ctx, c, params)
@@ -41,13 +39,11 @@ func (c *Client) CreateEdgeGateway(ctx context.Context, params types.ParamsCreat
 	}
 	return x.(*types.ModelEdgeGateway), nil
 }
-
 // Delete EdgeGateway performs a DELETE request to delete an edge gateway
 func (c *Client) DeleteEdgeGateway(ctx context.Context, params types.ParamsEdgeGateway) error {
 	_, err := cmds.Get("EdgeGateway", "", "Delete").Run(ctx, c, params)
 	return err
 }
-
 // Update EdgeGateway performs a PUT request to update an edge gateway
 func (c *Client) UpdateEdgeGateway(ctx context.Context, params types.ParamsUpdateEdgeGateway) (*types.ModelEdgeGateway, error) {
 	x, err := cmds.Get("EdgeGateway", "", "Update").Run(ctx, c, params)
@@ -56,3 +52,4 @@ func (c *Client) UpdateEdgeGateway(ctx context.Context, params types.ParamsUpdat
 	}
 	return x.(*types.ModelEdgeGateway), nil
 }
+

--- a/api/edgegateway/v1/zz_publicip.go
+++ b/api/edgegateway/v1/zz_publicip.go
@@ -15,7 +15,7 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
 )
 
-// This command allows you to create a new Public IP in the Edge Gateway.
+// This command allows you to create a new Public IP on the specified Edge Gateway.
 func (c *Client) CreatePublicIP(ctx context.Context, params types.ParamsEdgeGateway) (*types.ModelEdgeGatewayPublicIP, error) {
 	x, err := cmds.Get("EdgeGateway", "PublicIP", "Create").Run(ctx, c, params)
 	if err != nil {
@@ -23,7 +23,6 @@ func (c *Client) CreatePublicIP(ctx context.Context, params types.ParamsEdgeGate
 	}
 	return x.(*types.ModelEdgeGatewayPublicIP), nil
 }
-
 // This command allows you to list all Public IPs in the Edge Gateway.
 func (c *Client) ListPublicIP(ctx context.Context, params types.ParamsEdgeGateway) (*types.ModelEdgeGatewayPublicIPs, error) {
 	x, err := cmds.Get("EdgeGateway", "PublicIP", "List").Run(ctx, c, params)
@@ -32,7 +31,6 @@ func (c *Client) ListPublicIP(ctx context.Context, params types.ParamsEdgeGatewa
 	}
 	return x.(*types.ModelEdgeGatewayPublicIPs), nil
 }
-
 // This command allows you to retrieve information about a Public IP in the Edge Gateway.
 func (c *Client) GetPublicIP(ctx context.Context, params types.ParamsGetEdgeGatewayPublicIP) (*types.ModelEdgeGatewayPublicIP, error) {
 	x, err := cmds.Get("EdgeGateway", "PublicIP", "Get").Run(ctx, c, params)
@@ -41,9 +39,9 @@ func (c *Client) GetPublicIP(ctx context.Context, params types.ParamsGetEdgeGate
 	}
 	return x.(*types.ModelEdgeGatewayPublicIP), nil
 }
-
 // This command allows you to delete a Public IP in the Edge Gateway.
 func (c *Client) DeletePublicIP(ctx context.Context, params types.ParamsDeleteEdgeGatewayPublicIP) error {
 	_, err := cmds.Get("EdgeGateway", "PublicIP", "Delete").Run(ctx, c, params)
 	return err
 }
+

--- a/api/edgegateway/v1/zz_services.go
+++ b/api/edgegateway/v1/zz_services.go
@@ -23,7 +23,6 @@ func (c *Client) GetServices(ctx context.Context, params types.ParamsEdgeGateway
 	}
 	return x.(*types.ModelEdgeGatewayServices), nil
 }
-
 // Retrieve Cloud Avenue services on an EdgeGateway. This command returns the Cloud Avenue services available on the EdgeGateway, such as DNS, DHCP, and others.
 func (c *Client) GetCloudavenueServices(ctx context.Context, params types.ParamsEdgeGateway) (*types.ModelCloudavenueServices, error) {
 	x, err := cmds.Get("EdgeGateway", "CloudavenueServices", "Get").Run(ctx, c, params)
@@ -32,15 +31,14 @@ func (c *Client) GetCloudavenueServices(ctx context.Context, params types.Params
 	}
 	return x.(*types.ModelCloudavenueServices), nil
 }
-
-// Enable Cloud Avenue services on an EdgeGateway.
+// Enable Cloud Avenue services on an EdgeGateway. 
 func (c *Client) EnableCloudavenueServices(ctx context.Context, params types.ParamsEdgeGateway) error {
 	_, err := cmds.Get("EdgeGateway", "CloudavenueServices", "Enable").Run(ctx, c, params)
 	return err
 }
-
 // Disable Cloud Avenue services on an EdgeGateway. Cloudavenue services is a network setting that allows the EdgeGateway to connect to the mutualized Cloud Avenue services (DNS, DHCP, etc.).
 func (c *Client) DisableCloudavenueServices(ctx context.Context, params types.ParamsEdgeGateway) error {
 	_, err := cmds.Get("EdgeGateway", "CloudavenueServices", "Disable").Run(ctx, c, params)
 	return err
 }
+

--- a/api/edgegateway/v1/zz_t0.go
+++ b/api/edgegateway/v1/zz_t0.go
@@ -23,7 +23,6 @@ func (c *Client) ListT0(ctx context.Context) (*types.ModelT0s, error) {
 	}
 	return x.(*types.ModelT0s), nil
 }
-
 // Retrieve a specific T0 directly by its name or by the edge gateway it is associated with. This command allows you to fetch detailed information about a specific T0.
 func (c *Client) GetT0(ctx context.Context, params types.ParamsGetT0) (*types.ModelT0, error) {
 	x, err := cmds.Get("T0", "", "Get").Run(ctx, c, params)
@@ -32,3 +31,4 @@ func (c *Client) GetT0(ctx context.Context, params types.ParamsGetT0) (*types.Mo
 	}
 	return x.(*types.ModelT0), nil
 }
+

--- a/api/vdc/v1/zz_storage_profile.go
+++ b/api/vdc/v1/zz_storage_profile.go
@@ -15,6 +15,7 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
 )
 
+// List of storage profiles. If no filters are applied, all Storage Profiles for all VDCs are displayed. You can filter by either ID or Name of the storage profile, and you can also filter by either VDC ID or VDC Name. You can combine a storage profile filter (ID or Name) with a VDC filter (ID or Name). If both ID and Name are provided, they must refer to the same object; otherwise, the result will be empty.
 func (c *Client) ListStorageProfile(ctx context.Context, params types.ParamsListStorageProfile) (*types.ModelListStorageProfiles, error) {
 	x, err := cmds.Get("VDC", "StorageProfile", "List").Run(ctx, c, params)
 	if err != nil {
@@ -22,14 +23,14 @@ func (c *Client) ListStorageProfile(ctx context.Context, params types.ParamsList
 	}
 	return x.(*types.ModelListStorageProfiles), nil
 }
-
 // Add one or more storage profiles to a specific VDC.
 func (c *Client) AddStorageProfile(ctx context.Context, params types.ParamsAddStorageProfile) error {
 	_, err := cmds.Get("VDC", "StorageProfile", "Add").Run(ctx, c, params)
 	return err
 }
-
+// Delete a storage profile from a given VDC. You cannot delete the default storage profile, the last remaining profile, or a non-empty profile.
 func (c *Client) DeleteStorageProfile(ctx context.Context, params types.ParamsDeleteStorageProfile) error {
 	_, err := cmds.Get("VDC", "StorageProfile", "Delete").Run(ctx, c, params)
 	return err
 }
+

--- a/api/vdc/v1/zz_vdc.go
+++ b/api/vdc/v1/zz_vdc.go
@@ -23,7 +23,6 @@ func (c *Client) ListVDC(ctx context.Context, params types.ParamsListVDC) (*type
 	}
 	return x.(*types.ModelListVDC), nil
 }
-
 // Retrieve detailed information about a specific Virtual Data Center (VDC) by its name.
 func (c *Client) GetVDC(ctx context.Context, params types.ParamsGetVDC) (*types.ModelGetVDC, error) {
 	x, err := cmds.Get("VDC", "", "Get").Run(ctx, c, params)
@@ -32,7 +31,6 @@ func (c *Client) GetVDC(ctx context.Context, params types.ParamsGetVDC) (*types.
 	}
 	return x.(*types.ModelGetVDC), nil
 }
-
 // Create a new Virtual Data Center (VDC) with the specified parameters.
 func (c *Client) CreateVDC(ctx context.Context, params types.ParamsCreateVDC) (*types.ModelGetVDC, error) {
 	x, err := cmds.Get("VDC", "", "Create").Run(ctx, c, params)
@@ -41,15 +39,14 @@ func (c *Client) CreateVDC(ctx context.Context, params types.ParamsCreateVDC) (*
 	}
 	return x.(*types.ModelGetVDC), nil
 }
-
 // Update VDC performs a PUT request to update an existing VDC. Enter only the fields you want to update.
 func (c *Client) UpdateVDC(ctx context.Context, params types.ParamsUpdateVDC) error {
 	_, err := cmds.Get("VDC", "", "Update").Run(ctx, c, params)
 	return err
 }
-
 // Delete VDC performs a DELETE request to delete an existing VDC.
 func (c *Client) DeleteVDC(ctx context.Context, params types.ParamsDeleteVDC) error {
 	_, err := cmds.Get("VDC", "", "Delete").Run(ctx, c, params)
 	return err
 }
+

--- a/api/vdcgroup/v1/zz_vdcgroup.go
+++ b/api/vdcgroup/v1/zz_vdcgroup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
 )
 
+// List all Virtual Data Center Groups (Vdc Groups) available in your organization. If no filters are applied, it returns all Vdc Groups.
 func (c *Client) ListVdcGroup(ctx context.Context, params types.ParamsListVdcGroup) (*types.ModelListVdcGroup, error) {
 	x, err := cmds.Get("VdcGroup", "", "List").Run(ctx, c, params)
 	if err != nil {
@@ -22,7 +23,6 @@ func (c *Client) ListVdcGroup(ctx context.Context, params types.ParamsListVdcGro
 	}
 	return x.(*types.ModelListVdcGroup), nil
 }
-
 // Retrieve detailed information about a specific Vdc Group.
 func (c *Client) GetVdcGroup(ctx context.Context, params types.ParamsGetVdcGroup) (*types.ModelGetVdcGroup, error) {
 	x, err := cmds.Get("VdcGroup", "", "Get").Run(ctx, c, params)
@@ -31,7 +31,6 @@ func (c *Client) GetVdcGroup(ctx context.Context, params types.ParamsGetVdcGroup
 	}
 	return x.(*types.ModelGetVdcGroup), nil
 }
-
 // Create a new Virtual Data Center Group (Vdc Group) in your organization.
 func (c *Client) CreateVdcGroup(ctx context.Context, params types.ParamsCreateVdcGroup) (*types.ModelGetVdcGroup, error) {
 	x, err := cmds.Get("VdcGroup", "", "Create").Run(ctx, c, params)
@@ -40,7 +39,6 @@ func (c *Client) CreateVdcGroup(ctx context.Context, params types.ParamsCreateVd
 	}
 	return x.(*types.ModelGetVdcGroup), nil
 }
-
 // Update an existing Virtual Data Center Group (Vdc Group) in your organization.
 func (c *Client) UpdateVdcGroup(ctx context.Context, params types.ParamsUpdateVdcGroup) (*types.ModelGetVdcGroup, error) {
 	x, err := cmds.Get("VdcGroup", "", "Update").Run(ctx, c, params)
@@ -49,21 +47,19 @@ func (c *Client) UpdateVdcGroup(ctx context.Context, params types.ParamsUpdateVd
 	}
 	return x.(*types.ModelGetVdcGroup), nil
 }
-
 // Delete an existing Virtual Data Center Group (Vdc Group) from your organization.
 func (c *Client) DeleteVdcGroup(ctx context.Context, params types.ParamsDeleteVdcGroup) error {
 	_, err := cmds.Get("VdcGroup", "", "Delete").Run(ctx, c, params)
 	return err
 }
-
 // Add an existing Virtual Data Center (Vdc) to a Virtual Data Center Group (Vdc Group) in your organization.
 func (c *Client) AddVdcToVdcGroup(ctx context.Context, params types.ParamsAddVdcToVdcGroup) error {
 	_, err := cmds.Get("VdcGroup", "Vdc", "Add").Run(ctx, c, params)
 	return err
 }
-
 // Remove one or more Vdc from a Vdc Group. This action will disassociate the specified Vdc(s) from the Vdc Group.
 func (c *Client) RemoveVdcFromVdcGroup(ctx context.Context, params types.ParamsRemoveVdcFromVdcGroup) error {
 	_, err := cmds.Get("VdcGroup", "Vdc", "Remove").Run(ctx, c, params)
 	return err
 }
+

--- a/cmd/devtool/command.go
+++ b/cmd/devtool/command.go
@@ -19,6 +19,7 @@ import (
 	"github.com/k0kubun/pp/v3"
 	"github.com/spf13/cobra"
 
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/api/draas/v1"
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/api/edgegateway/v1"
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/api/vdc/v1"
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/api/vdcgroup/v1"
@@ -117,6 +118,8 @@ var commandCmd = &cobra.Command{
 			cmdClient, _ = edgegateway.New(client)
 		case "vdcgroup":
 			cmdClient, _ = vdcgroup.New(client)
+		case "draas":
+			cmdClient, _ = draas.New(client)
 		default:
 			log.Error("Unknown namespace", "namespace", command.GetNamespace())
 		}

--- a/endpoints/zz_draas.go
+++ b/endpoints/zz_draas.go
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package endpoints
+
+import (
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav"
+)
+
+// ListDraasOnPremiseIp - List of on premise IP addresses allowed for this organization's draas offer
+//
+// DocumentationURL: https://swagger.cloudavenue.orange-business.com/#/VCDA/getVcdaIPs 
+func ListDraasOnPremiseIp() *cav.Endpoint {
+	return cav.MustGetEndpoint("ListDraasOnPremiseIp")
+}
+// AddDraasOnPremiseIp - Allow a new on premise IP address for this organization's draas offer
+//
+// DocumentationURL: https://swagger.cloudavenue.orange-business.com/#/VCDA/postVcdaIPs 
+func AddDraasOnPremiseIp() *cav.Endpoint {
+	return cav.MustGetEndpoint("AddDraasOnPremiseIp")
+}
+// RemoveDraasOnPremiseIp - Remove an on premise IP address from this organization's draas offer
+//
+// DocumentationURL: https://swagger.cloudavenue.orange-business.com/#/VCDA/deleteVcdaIPs 
+func RemoveDraasOnPremiseIp() *cav.Endpoint {
+	return cav.MustGetEndpoint("RemoveDraasOnPremiseIp")
+}

--- a/internal/iendpoints/draas.go
+++ b/internal/iendpoints/draas.go
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package iendpoints
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/itypes"
+	"github.com/orange-cloudavenue/common-go/generator"
+	"github.com/orange-cloudavenue/common-go/validators"
+)
+
+//go:generate endpoint-generator -path draas.go -output draas
+
+func init() {
+	// * ListDraasOnPremiseIP
+	cav.Endpoint{
+		DocumentationURL: "https://swagger.cloudavenue.orange-business.com/#/VCDA/getVcdaIPs",
+		Name:             "ListDraasOnPremiseIp",
+		Description:      "List of on premise IP addresses allowed for this organization's draas offer",
+		Method:           cav.MethodGET,
+		SubClient:        cav.ClientCerberus,
+		PathTemplate:     "/api/customers/v2.0/vcda/ips",
+		BodyResponseType: itypes.ApiResponseListDraasOnPremise{},
+		MockResponseFunc: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			ips := itypes.ApiResponseListDraasOnPremise{generator.MustGenerate("{ipv4address}"), generator.MustGenerate("{ipv4address}")}
+			j, _ := json.Marshal(ips)
+			// Return a mock response
+			w.Header().Set("Content-Type", "application/json")
+			// ignore write body error for mock response
+			w.Write(j) //nolint:errcheck
+		}),
+	}.Register()
+
+	// * AddDraasOnPremiseIp
+	cav.Endpoint{
+		DocumentationURL: "https://swagger.cloudavenue.orange-business.com/#/VCDA/postVcdaIPs",
+		Name:             "AddDraasOnPremiseIp",
+		Description:      "Allow a new on premise IP address for this organization's draas offer",
+		Method:           cav.MethodPOST,
+		SubClient:        cav.ClientCerberus,
+		PathTemplate:     "/api/customers/v2.0/vcda/ips/{ip}",
+		PathParams: []cav.PathParam{
+			{
+				Name:        "ip",
+				Description: "The on premise IP address to allow",
+				Required:    true,
+				ValidatorFunc: func(v string) error {
+					return validators.New().Var(v, "ipv4")
+				},
+			},
+		},
+	}.Register()
+
+	// * RemoveDraasOnPremiseIp
+	cav.Endpoint{
+		DocumentationURL: "https://swagger.cloudavenue.orange-business.com/#/VCDA/deleteVcdaIPs",
+		Name:             "RemoveDraasOnPremiseIp",
+		Description:      "Remove an on premise IP address from this organization's draas offer",
+		Method:           cav.MethodDELETE,
+		SubClient:        cav.ClientCerberus,
+		PathTemplate:     "/api/customers/v2.0/vcda/ips/{ip}",
+		PathParams: []cav.PathParam{
+			{
+				Name:        "ip",
+				Description: "The on premise IP address to remove",
+				Required:    true,
+				ValidatorFunc: func(v string) error {
+					return validators.New().Var(v, "ipv4")
+				},
+			},
+		},
+	}.Register()
+}

--- a/internal/iendpoints/storage_profile.go
+++ b/internal/iendpoints/storage_profile.go
@@ -18,13 +18,12 @@ import (
 
 	"resty.dev/v3"
 
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav"
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/itypes"
 	"github.com/orange-cloudavenue/common-go/extractor"
 	"github.com/orange-cloudavenue/common-go/generator"
 	"github.com/orange-cloudavenue/common-go/urn"
 	"github.com/orange-cloudavenue/common-go/validators"
-
-	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/cav"
-	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/itypes"
 )
 
 //go:generate endpoint-generator -path storage_profile.go -output storage_profile

--- a/internal/itypes/draas.go
+++ b/internal/itypes/draas.go
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package itypes
+
+import (
+	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
+)
+
+type (
+	ApiResponseListDraasOnPremise []string
+	ApiRequestAddDraasOnPremiseIP string
+)
+
+func (r ApiResponseListDraasOnPremise) ToModel() *types.ModelListDraasOnPremise {
+	return &types.ModelListDraasOnPremise{
+		IPs: []string(r),
+	}
+}

--- a/types/draas.go
+++ b/types/draas.go
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package types
+
+type (
+	ModelListDraasOnPremise struct {
+		IPs []string `documentation:"List of OnPremise IPs for this organization's draas offer"`
+	}
+
+	ParamsAddDraasOnPremiseIP struct {
+		IP string
+	}
+
+	ParamsRemoveDraasOnPremiseIP struct {
+		IP string
+	}
+)


### PR DESCRIPTION
This pull request introduces a new DRaaS (Disaster Recovery as a Service) client implementation in the `api/draas/v1` package, including its command registry, core client logic, command definitions for managing OnPremise IPs, and comprehensive test coverage. The changes also include minor formatting and comment improvements in the existing EdgeGateway API files for consistency.

### DRaaS Client Implementation

* Added a new `Client` type in `client.go` to encapsulate DRaaS operations, with initialization logic and logger support.
* Registered DRaaS and OnPremise IP commands, including list, add, and remove operations, in `draas_commands.go` and `draas_on_premise_commands.go`. [[1]](diffhunk://#diff-907293fdb36e855f43d699068796ab362929399c7022fd3387af1ba749c04320R1-R22) [[2]](diffhunk://#diff-defb8dcbc2e911e16e97958ac3ea94641f83aff1b87adefb491a93e7af1970c3R1-R132)
* Implemented high-level client methods for listing, adding, and removing OnPremise IPs in `zz_draas_on_premise.go`.

### Command Registry and Helpers

* Created a DRaaS command registry in `commands.go` for managing available commands.
* Added a test helper in `helper_test.go` for creating mock clients in tests.

### Test Coverage

* Added tests for client initialization and error handling in `client_test.go`.
* Added extensive tests for OnPremise IP management (list, add, remove) in `draas_on_premise_test.go`, including validation and error scenarios.

### Minor Improvements to EdgeGateway API

* Improved formatting and updated comments for clarity in EdgeGateway API files (`zz_bandwidth.go`, `zz_edgegateway.go`, `zz_publicip.go`, `zz_services.go`, `zz_t0.go`). [[1]](diffhunk://#diff-40694675b13474d9e91e2d613d3cab7686d6d331b2bc533c81342f0162cadc7aR26) [[2]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL26) [[3]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL35) [[4]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL44-L50) [[5]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cR55) [[6]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L18-L26) [[7]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L35) [[8]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L44-R47) [[9]](diffhunk://#diff-12dd6e4196fe7e538ab746b80f80856b8b1837dc71528eda38c86f6e68c94420L26) [[10]](diffhunk://#diff-12dd6e4196fe7e538ab746b80f80856b8b1837dc71528eda38c86f6e68c94420L35-R44) [[11]](diffhunk://#diff-6a9903a40d84c6e316f9faa105c3da47e467cfd3c8f0579da798657f4fb793e9L26) [[12]](diffhunk://#diff-6a9903a40d84c6e316f9faa105c3da47e467cfd3c8f0579da798657f4fb793e9R34)