### PR TITLE
chore: add new command http

### DIFF
--- a/cav/client_request.go
+++ b/cav/client_request.go
@@ -17,6 +17,35 @@ import (
 	"resty.dev/v3"
 )
 
+// NewRawRequest creates a new raw request using the resty client.
+func (c *client) NewRawRequest(ctx context.Context, subclientName string) (req *resty.Request, err error) {
+	// Retrieve the subclient based on the provided client name.
+	// This method identifies the subclient and returns it.
+
+	// Retrieve the subclient based on the provided client name.
+	// This method identifies the subclient and returns it.
+	sc, err := c.identifyClient(ctx, subClientName(subclientName))
+	if err != nil {
+		return nil, err
+	}
+
+	// Inject the client name into the context for retrieval in the other methods.
+	ctxv := context.WithValue(ctx, contextKeyClientName, subClientName(subclientName))
+
+	// Setup the HTTP client for the request.
+	// This client is used to send the request and handle the response.
+	hC, err := sc.newHTTPClient(ctxv)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new request with the context and options.
+	hR := hC.NewRequest().
+		SetContext(ctxv)
+
+	return hR, nil
+}
+
 // NewRequest creates a new request using the resty client.
 func (c *client) NewRequest(ctx context.Context, endpoint *Endpoint, _ ...RequestOption) (req *resty.Request, err error) {
 	// Retrieve the subclient based on the provided client name.

--- a/cmd/devtool/http-client.go
+++ b/cmd/devtool/http-client.go
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/niemeyer/pretty"
+	"github.com/spf13/cobra"
+	"resty.dev/v3"
+)
+
+type clientRawRequest interface {
+	NewRawRequest(ctx context.Context, subclientName string) (req *resty.Request, err error)
+}
+
+var endpointHTTP = &cobra.Command{
+	Use:   "http [name]",
+	Short: "Test an http Endpoint with custom subclient",
+	Long:  `Allows you to test an HTTP endpoint by specifying its custom subclient.`,
+	Args:  cobra.ExactArgs(1),
+	Example: `
+# GET
+http --subclient vmware --logger debug --header "Accept:application/*;version=38.1" /cloudapi/1.0.0/site/settings
+
+# POST
+http --subclient vmware --logger debug --body='{"key":"value"}' --method=POST /my/endpoint
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		client, err := newClient()
+		if err != nil {
+			fmt.Printf("Error creating client: %v\n", err)
+			return
+		}
+
+		clientRaw, ok := client.(clientRawRequest)
+		if !ok {
+			fmt.Printf("Error asserting client to clientRawRequest: %v\n", err)
+			return
+		}
+
+		req, err := clientRaw.NewRawRequest(context.Background(), cmdHttpSubclientName)
+		if err != nil {
+			fmt.Printf("Error creating raw request: %v\n", err)
+			return
+		}
+
+		req.SetBody(cmdHttpBody)
+		req.EnableDebug()
+		req.EnableTrace()
+
+		for _, header := range cmdHttpHeaders {
+			h := strings.SplitN(header, ":", 2)
+			if len(h) != 2 {
+				fmt.Printf("Invalid header format: %s\n", header)
+				continue
+			}
+			req.SetHeader(strings.TrimSpace(h[0]), strings.TrimSpace(h[1]))
+		}
+
+		resp, err := req.Execute(cmdHttpMethod, args[0])
+		if err != nil {
+			fmt.Printf("Error executing request: %v\n", err)
+			return
+		}
+
+		pretty.Print(resp.Result())
+	},
+}
+
+var (
+	cmdHttpSubclientName string
+	cmdHttpBody          string
+	cmdHttpMethod        string
+	cmdHttpHeaders       []string
+)
+
+func init() {
+	endpointHTTP.Flags().StringVar(&cmdHttpBody, "body", "", "Request body as a JSON string")
+	endpointHTTP.Flags().StringVar(&cmdHttpSubclientName, "subclient", "", "Subclient name")
+	endpointHTTP.Flags().StringVar(&cmdHttpMethod, "method", "GET", "HTTP method")
+	endpointHTTP.Flags().StringSliceVar(&cmdHttpHeaders, "header", []string{}, "Request headers (key:value)")
+
+	rootCmd.AddCommand(endpointHTTP)
+}


### PR DESCRIPTION
This pull request introduces a new CLI command for testing HTTP endpoints with custom subclients, as well as supporting changes to enable raw HTTP requests using the Resty client. The main focus is on improving developer experience by allowing flexible, low-level HTTP requests directly from the CLI.

**New CLI command and HTTP request functionality:**

* Added a new file `cmd/endpoint-dev/http-client.go` that defines the `http` subcommand, allowing users to send customizable HTTP requests to endpoints using a specified subclient. The command supports setting the request body, method, and headers, and prints the response in a readable format.
* Introduced the `NewRawRequest` method to the `client` type in `cav/client_request.go`, enabling creation of raw Resty requests for a given subclient. This method handles subclient identification and HTTP client setup.

**Dependency management:**

* Added `resty.dev/v3 v3.0.0-beta.3` as a direct dependency in `cmd/endpoint-dev/go.mod` to support raw HTTP requests.
* Removed `resty.dev/v3 v3.0.0-beta.3` from the indirect dependencies in `cmd/endpoint-dev/go.mod` to reflect its new direct usage.