### PR TITLE
feat: Add Update Storage profile command

### DIFF
--- a/api/vdc/v1/zz_storage_profile.go
+++ b/api/vdc/v1/zz_storage_profile.go
@@ -35,3 +35,12 @@ func (c *Client) DeleteStorageProfile(ctx context.Context, params types.ParamsDe
 	_, err := cmds.Get("VDC", "StorageProfile", "Delete").Run(ctx, c, params)
 	return err
 }
+
+// Update one or multiple storage profiles in a given VDC. You can update the limit and/or set a storage profile as default. You cannot update the class name of a storage profile.
+func (c *Client) UpdateStorageProfile(ctx context.Context, params types.ParamsUpdateStorageProfile) (*types.ModelListStorageProfilesVDC, error) {
+	x, err := cmds.Get("VDC", "StorageProfile", "Update").Run(ctx, c, params)
+	if err != nil {
+		return nil, err
+	}
+	return x.(*types.ModelListStorageProfilesVDC), nil
+}

--- a/cmd/devref/functionalities.json
+++ b/cmd/devref/functionalities.json
@@ -89,14 +89,6 @@
         "markdown_documentation": "",
         "params": [
           {
-            "name": "owner_type",
-            "description": "The type of the owner of the edge gateway.",
-            "required": true,
-            "example": "",
-            "type": "string",
-            "validators_description": "Validates that the value is one of: `vdc`, `vdcgroup`. \n"
-          },
-          {
             "name": "owner_name",
             "description": "The name of the VDC or VDC Group that this edge gateway belongs to.",
             "required": true,
@@ -108,7 +100,7 @@
             "name": "t0_name",
             "description": "The name of the T0 router that this edge gateway will be connected to. If not provided and only if one T0 router is available, the first T0 router will be used.",
             "required": false,
-            "example": "tn01e02ocb0001234spt101",
+            "example": "prvrf01eocb0001234allsp01",
             "type": "string",
             "validators_description": "Validates that the value is a valid T0 name (pr01e02ocb0001234spt101).. \n"
           },
@@ -175,7 +167,7 @@
             "required": false,
             "example": "",
             "type": "string",
-            "validators_description": "The value is required if the parameter `Name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
+            "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
           },
           {
             "name": "name",
@@ -183,7 +175,7 @@
             "required": false,
             "example": "",
             "type": "string",
-            "validators_description": "The value is required if the parameter `ID` is null., "
+            "validators_description": "The value is required if the parameter `id` is null., "
           }
         ],
         "deprecated": false,
@@ -204,7 +196,7 @@
             "required": false,
             "example": "",
             "type": "string",
-            "validators_description": "The value is required if the parameter `Name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
+            "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
           },
           {
             "name": "name",
@@ -212,7 +204,7 @@
             "required": false,
             "example": "",
             "type": "string",
-            "validators_description": "The value is required if the parameter `ID` is null., Validates that the value is a valid Edge Gateway name (tn01e02ocb0001234spt101).. \n"
+            "validators_description": "The value is required if the parameter `id` is null., Validates that the value is a valid Edge Gateway name (tn01e02ocb0001234spt101).. \n"
           }
         ],
         "deprecated": false,
@@ -317,7 +309,7 @@
             "required": false,
             "example": "",
             "type": "string",
-            "validators_description": "The value is required if the parameter `Name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
+            "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
           },
           {
             "name": "name",
@@ -325,7 +317,7 @@
             "required": false,
             "example": "",
             "type": "string",
-            "validators_description": "The value is required if the parameter `ID` is null., "
+            "validators_description": "The value is required if the parameter `id` is null., "
           },
           {
             "name": "bandwidth",
@@ -424,7 +416,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:96ac09c3-b5be-4443-b392-17c3b608ea4f",
+                "example": "urn:vcloud:gateway:143f1a19-df5d-47a7-850c-d810e2949cbd",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -453,7 +445,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:4460a513-0825-4241-a683-12c721927b83",
+                "example": "urn:vcloud:gateway:aab95ae4-9226-4d54-88ec-9c291e90ae39",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -1306,7 +1298,7 @@
             "required": true,
             "example": "my-vdc",
             "type": "string",
-            "validators_description": ""
+            "validators_description": "Validates that the value is a valid VDC name (\u003calphanumeric\u003e with - _ character and with max length 27 and min length 2).. \n"
           },
           {
             "name": "description",
@@ -1774,7 +1766,7 @@
             "required": false,
             "example": "my-vdc",
             "type": "string",
-            "validators_description": "The value is required if the parameter `id` is null., "
+            "validators_description": "The value is required if the parameter `id` is null., Validates that the value is a valid VDC name (\u003calphanumeric\u003e with - _ character and with max length 27 and min length 2).. \n"
           }
         ],
         "deprecated": false,
@@ -1801,9 +1793,9 @@
             "name": "name",
             "description": "Name of the VDC to get",
             "required": false,
-            "example": "",
+            "example": "my-vdc",
             "type": "string",
-            "validators_description": "The value is required if the parameter `id` is null., "
+            "validators_description": "The value is required if the parameter `id` is null., Validates that the value is a valid VDC name (\u003calphanumeric\u003e with - _ character and with max length 27 and min length 2).. \n"
           }
         ],
         "deprecated": false,
@@ -1938,7 +1930,7 @@
             "required": false,
             "example": "",
             "type": "string",
-            "validators_description": ""
+            "validators_description": "Validates that the value is a valid VDC name (\u003calphanumeric\u003e with - _ character and with max length 27 and min length 2).. \n"
           }
         ],
         "deprecated": false,
@@ -2008,7 +2000,7 @@
             "required": false,
             "example": "my-vdc",
             "type": "string",
-            "validators_description": "The value is required if the parameter `id` is null., "
+            "validators_description": "The value is required if the parameter `id` is null., Validates that the value is a valid VDC name (\u003calphanumeric\u003e with - _ character and with max length 27 and min length 2).. \n"
           },
           {
             "name": "description",
@@ -2325,17 +2317,180 @@
               {
                 "object": "vdcs.{index}.storage_profiles.{index}.limit",
                 "type": "int",
-                "documentation": "Limit of the storage profile in MB"
+                "documentation": "Limit of the storage profile in GiB"
               },
               {
                 "object": "vdcs.{index}.storage_profiles.{index}.used",
                 "type": "int",
-                "documentation": "Used storage of the storage profile in MB"
+                "documentation": "Used storage of the storage profile in GiB"
               },
               {
                 "object": "vdcs.{index}.storage_profiles.{index}.default",
                 "type": "bool",
-                "documentation": "Is this storage profile the default one?"
+                "documentation": "Indicates if the storage profile is the default one"
+              }
+            ]
+          },
+          "Update": {
+            "namespace": "VDC",
+            "resource": "StorageProfile",
+            "verb": "Update",
+            "short_documentation": "Update a VDC Storage Profile",
+            "long_documentation": "Update one or multiple storage profiles in a given VDC. You can update the limit and/or set a storage profile as default. You cannot update the class name of a storage profile.",
+            "markdown_documentation": "",
+            "params": [
+              {
+                "name": "vdc_id",
+                "description": "ID of the VDC to update the storage profile from",
+                "required": false,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `vdc_name` is null., Validates that the value is a valid URN (`vdc`).. \n"
+              },
+              {
+                "name": "vdc_name",
+                "description": "Name of the VDC to update the storage profile from",
+                "required": false,
+                "example": "my-vdc",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `vdc_id` is null., "
+              },
+              {
+                "name": "storage_profiles.{index}.class",
+                "description": "Class of the storage profile to update. This is the identifier of the storage profile to update. Refer to the Rules Table below for valid classes.",
+                "required": true,
+                "example": "gold",
+                "type": "string",
+                "validators_description": ""
+              },
+              {
+                "name": "storage_profiles.{index}.default",
+                "description": "Set the storage profile as default. There can be only one default storage profile per VDC.",
+                "required": false,
+                "example": "true",
+                "type": "bool",
+                "validators_description": ""
+              },
+              {
+                "name": "storage_profiles.{index}.limit",
+                "description": "Limit of the storage profile to update in GiB. This is the maximum amount of storage that can be used by the VDC. The new limit cannot be less than the current used storage. Warning: Decreasing the limit may lead to service disruption if the current usage exceeds the new limit.",
+                "required": false,
+                "example": "500",
+                "type": "int",
+                "validators_description": "Validates that the value is between 100 and 81920. \n"
+              }
+            ],
+            "deprecated": false,
+            "deprecated_message": "",
+            "model": [
+              {
+                "object": "id",
+                "type": "string",
+                "documentation": "ID of the VDC"
+              },
+              {
+                "object": "name",
+                "type": "string",
+                "documentation": "Name of the VDC"
+              },
+              {
+                "object": "storage_profiles.{index}.id",
+                "type": "string",
+                "documentation": "ID of the storage profile"
+              },
+              {
+                "object": "storage_profiles.{index}.class",
+                "type": "string",
+                "documentation": "Name of the storage profile"
+              },
+              {
+                "object": "storage_profiles.{index}.limit",
+                "type": "int",
+                "documentation": "Limit of the storage profile in GiB"
+              },
+              {
+                "object": "storage_profiles.{index}.used",
+                "type": "int",
+                "documentation": "Used storage of the storage profile in GiB"
+              },
+              {
+                "object": "storage_profiles.{index}.default",
+                "type": "bool",
+                "documentation": "Indicates if the storage profile is the default one"
+              }
+            ],
+            "rules": [
+              {
+                "consoles": null,
+                "whenHuman": "(disponibility_class = ONE-ROOM)",
+                "when": {
+                  "or": [
+                    {
+                      "field": "disponibility_class",
+                      "value": "ONE-ROOM"
+                    }
+                  ]
+                },
+                "target": "storage_profiles.{index}.class",
+                "enum": [
+                  "silver",
+                  "gold",
+                  "platinum3k",
+                  "platinum7k",
+                  "^(silver|gold|platinum[3|7]{1}k)_(ocb[0-9]{1,7})$"
+                ],
+                "description": "Storage profile class allowed for Disponibility Class ONE-ROOM"
+              },
+              {
+                "consoles": [
+                  "Console Externe VDR",
+                  "Console Interne VDR"
+                ],
+                "whenHuman": "(disponibility_class = DUAL-ROOM)",
+                "when": {
+                  "or": [
+                    {
+                      "field": "disponibility_class",
+                      "value": "DUAL-ROOM"
+                    }
+                  ]
+                },
+                "target": "storage_profiles.{index}.class",
+                "enum": [
+                  "silver_r1",
+                  "silver_r2",
+                  "gold_r1",
+                  "gold_r2",
+                  "platinum3k_r1",
+                  "platinum3k_r2",
+                  "platinum7k_r1",
+                  "platinum7k_r2",
+                  "^(silver|gold|platinum[3|7]{1}k)_(ocb[0-9]{1,7})_(r1|r2)$"
+                ],
+                "description": "Storage profile class allowed for Disponibility Class DUAL-ROOM"
+              },
+              {
+                "consoles": [
+                  "Console Externe VDR",
+                  "Console Interne VDR"
+                ],
+                "whenHuman": "(disponibility_class = HA-DUAL-ROOM)",
+                "when": {
+                  "or": [
+                    {
+                      "field": "disponibility_class",
+                      "value": "HA-DUAL-ROOM"
+                    }
+                  ]
+                },
+                "target": "storage_profiles.{index}.class",
+                "enum": [
+                  "gold_hm",
+                  "platinum3k_hm",
+                  "platinum7k_hm",
+                  "^(gold|platinum[3|7]{1}k)_(ocb[0-9]{1,7})_(hm)$"
+                ],
+                "description": "Storage profile class allowed for Disponibility Class HA-DUAL-ROOM"
               }
             ]
           }

--- a/cmd/devref/go.mod
+++ b/cmd/devref/go.mod
@@ -22,11 +22,11 @@ require (
 	github.com/orange-cloudavenue/common-go/extractor v1.0.1 // indirect
 	github.com/orange-cloudavenue/common-go/generator v1.3.4 // indirect
 	github.com/orange-cloudavenue/common-go/internal/regex v0.0.0-20250812201424-07c3423160b3 // indirect
-	github.com/orange-cloudavenue/common-go/regex v1.1.1 // indirect
+	github.com/orange-cloudavenue/common-go/regex v1.2.0 // indirect
 	github.com/orange-cloudavenue/common-go/strcase v1.0.0 // indirect
 	github.com/orange-cloudavenue/common-go/urn v1.2.0 // indirect
 	github.com/orange-cloudavenue/common-go/utils v1.0.0 // indirect
-	github.com/orange-cloudavenue/common-go/validators v1.1.3 // indirect
+	github.com/orange-cloudavenue/common-go/validators v1.2.0 // indirect
 	golang.org/x/crypto v0.40.0 // indirect
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect

--- a/cmd/devref/go.sum
+++ b/cmd/devref/go.sum
@@ -24,8 +24,8 @@ github.com/orange-cloudavenue/common-go/generator v1.3.4 h1:AFsosY54L69rSpomcFt2
 github.com/orange-cloudavenue/common-go/generator v1.3.4/go.mod h1:t2twRGIC+pgneyUEb3Cf8EN0l+oFHl4E5bkLn/mF8Bo=
 github.com/orange-cloudavenue/common-go/internal/regex v0.0.0-20250812201424-07c3423160b3 h1:LvDc/VwHDkB9IfEdYf6y1m7GMnwV2bTw/P4BkO+wxY8=
 github.com/orange-cloudavenue/common-go/internal/regex v0.0.0-20250812201424-07c3423160b3/go.mod h1:T7OxerHaO1q+P6ue/Ka93aoUQK8syveiYhfZaJBMfP0=
-github.com/orange-cloudavenue/common-go/regex v1.1.1 h1:ET1iIsIoZz5fuHkNcp7kr7OzRDTlfpKxAtQwkAJmikg=
-github.com/orange-cloudavenue/common-go/regex v1.1.1/go.mod h1:A7DfA7aAObMJ7DQSBPtVxbr54x0G2WDh4qf40RhZF+0=
+github.com/orange-cloudavenue/common-go/regex v1.2.0 h1:mJLWYPL1wEllGx9h4YEvsV7Q3X+igSWOzt6NIiYLxV8=
+github.com/orange-cloudavenue/common-go/regex v1.2.0/go.mod h1:A7DfA7aAObMJ7DQSBPtVxbr54x0G2WDh4qf40RhZF+0=
 github.com/orange-cloudavenue/common-go/strcase v1.0.0 h1:96+dUHYq91/hiXY/DKO9HGTP3FMsSLikcf/xsp7tqLw=
 github.com/orange-cloudavenue/common-go/strcase v1.0.0/go.mod h1:WGZdlDEE39Yar+OU9pgjMGXMlQWgJrgOOc4q72qNVGE=
 github.com/orange-cloudavenue/common-go/urn v1.2.0 h1:FWjMj4aiCJwTb6UAGavthmTTE/KSKGFc3bi2cbNk3r8=

--- a/commands/params_path.go
+++ b/commands/params_path.go
@@ -135,10 +135,16 @@ func StoreValueAtPath(params interface{}, path, value string) error {
 			if err != nil {
 				return fmt.Errorf("expected integer index for slice/array at '%s', got '%s'", strings.Join(parts[:i], "."), part)
 			}
-			if index < 0 || index >= val.Len() {
-				// Add init the slice
-				newElem := reflect.New(val.Type().Elem()).Elem()
-				val.Set(reflect.Append(val, newElem))
+			if index < 0 {
+				return fmt.Errorf("negative index for slice/array at '%s'", strings.Join(parts[:i], "."))
+			}
+			if index >= val.Len() {
+				// Expand the slice to the necessary size
+				sliceType := val.Type()
+				newLen := index + 1
+				newSlice := reflect.MakeSlice(sliceType, newLen, newLen)
+				reflect.Copy(newSlice, val)
+				val.Set(newSlice)
 			}
 			val = val.Index(index)
 		case reflect.Map:

--- a/internal/iendpoints/storage_profile.go
+++ b/internal/iendpoints/storage_profile.go
@@ -133,6 +133,7 @@ func init() {
 		// ResponseMiddlewares is used to extract the ID from the response and set it in the context
 		ResponseMiddlewares: []resty.ResponseMiddleware{
 			func(_ *resty.Client, resp *resty.Response) error {
+				// Extract ID and VDCID from HREF and set it in the context
 				r := resp.Result().(*itypes.ApiResponseListStorageProfiles)
 
 				for i, strPro := range r.StorageProfiles {
@@ -149,6 +150,17 @@ func init() {
 						return fmt.Errorf("failed to extract VDC ID from HREF: %w", err)
 					}
 					r.StorageProfiles[i].VdcID = urn.Normalize(urn.VDC, vdcID).String()
+				}
+
+				return nil
+			},
+			// modify response for limit and used fields to transform values in GiB instead of MiB
+			func(_ *resty.Client, resp *resty.Response) error {
+				r := resp.Result().(*itypes.ApiResponseListStorageProfiles)
+
+				for i, strPro := range r.StorageProfiles {
+					r.StorageProfiles[i].Limit = strPro.Limit / 1024
+					r.StorageProfiles[i].Used = strPro.Used / 1024
 				}
 
 				return nil

--- a/internal/itypes/vdc_storage_profile.go
+++ b/internal/itypes/vdc_storage_profile.go
@@ -14,7 +14,7 @@ import "github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
 type (
 	// * ListStorageProfiles
 	ApiResponseListStorageProfiles struct {
-		StorageProfiles []ApiResponseListStorageProfile `json:"record" fakesize:"2"`
+		StorageProfiles []ApiResponseListStorageProfile `json:"record" fakesize:"1"`
 	}
 
 	ApiResponseListStorageProfile struct {
@@ -25,8 +25,8 @@ type (
 		IsDefaultStorageProfile bool   `json:"isDefaultStorageProfile" fake:"true"`
 
 		// Values are in MB
-		Limit int `json:"storageLimitMB" fake:"{number:100,1000}"` //nolint:tagliatelle
-		Used  int `json:"storageUsedMB" fake:"{number:10,500}"`    //nolint:tagliatelle
+		Limit int `json:"storageLimitMB" fake:"{number:100000,81920000}"` //nolint:tagliatelle
+		Used  int `json:"storageUsedMB" fake:"{number:1000,100000}"`      //nolint:tagliatelle
 
 		// Vdc information
 		VdcID   string `json:"vdc" fake:"{href_uuid}"` //nolint:revive

--- a/types/vdc.go
+++ b/types/vdc.go
@@ -117,6 +117,13 @@ type (
 		Default bool
 	}
 
+	// ParamsUpdateVDCStorageProfile defines the parameters for updating a storage profile in a VDC.
+	ParamsUpdateVDCStorageProfile struct {
+		Class   string
+		Limit   int
+		Default *bool
+	}
+
 	// ParamsDeleteVDCStorageProfile defines the parameters for deleting a storage profile from a VDC.
 	ParamsDeleteVDCStorageProfile struct {
 		Class string

--- a/types/vdc_storage_profile.go
+++ b/types/vdc_storage_profile.go
@@ -23,40 +23,35 @@ type (
 	ModelListStorageProfile struct {
 		ID      string `documentation:"ID of the storage profile"`
 		Class   string `documentation:"Name of the storage profile"`
-		Limit   int    `documentation:"Limit of the storage profile in MB"`
-		Used    int    `documentation:"Used storage of the storage profile in MB"`
-		Default bool   `documentation:"Is this storage profile the default one?"`
+		Limit   int    `documentation:"Limit of the storage profile in GiB"`
+		Used    int    `documentation:"Used storage of the storage profile in GiB"`
+		Default bool   `documentation:"Indicates if the storage profile is the default one"`
 	}
 )
 
 type (
-	// ParamsListStorageProfile defines the parameters for listing storage profiles in a VDC.
 	ParamsListStorageProfile struct {
-		// ID is the unique identifier of storage profiles from.
-		ID string `documentation:"ID of the storage profile"`
-		// Name is the name of the storage profiles to filter by.
-		Name string `documentation:"Name of the storage profiles to filter by"`
-		// VDCID is the unique identifier of the VDC to get storage profiles from.
-		VdcID string `documentation:"ID of the VDC to get storage profiles from"` //nolint:revive
-		// Name is the name of the VDC to get storage profiles from.
-		VdcName string `documentation:"Name of the VDC to get storage profiles from"` //nolint:revive
+		ID      string
+		Name    string
+		VdcID   string //nolint:revive
+		VdcName string //nolint:revive
 	}
 
 	ParamsAddStorageProfile struct {
-		// VdcId is the unique identifier of the VDC to add the storage profile to.
-		VdcID string //nolint:revive
-		// VdcName is the name of the VDC to add the storage profile to.
-		VdcName string //nolint:revive
-
+		VdcID           string //nolint:revive
+		VdcName         string //nolint:revive
 		StorageProfiles []ParamsCreateVDCStorageProfile
 	}
 
+	ParamsUpdateStorageProfile struct {
+		VdcID           string //nolint:revive
+		VdcName         string //nolint:revive
+		StorageProfiles []ParamsUpdateVDCStorageProfile
+	}
+
 	ParamsDeleteStorageProfile struct {
-		// VdcId is the unique identifier of the VDC to delete the storage profile
-		VdcID string //nolint:revive
-		// VdcName is the name of the VDC to delete the storage profile from
-		VdcName string //nolint:revive
-		// StorageProfile is the list of storage profiles to delete, in this case it is a single storage profile
+		VdcID           string //nolint:revive
+		VdcName         string //nolint:revive
 		StorageProfiles []ParamsDeleteVDCStorageProfile
 	}
 )


### PR DESCRIPTION
This pull request introduces a new command for updating VDC storage profiles and makes several minor improvements and cleanups across the API client codebase. The most significant change is the addition of the `UpdateStorageProfile` command, which enables updating limits and default status for storage profiles within a VDC, along with comprehensive validation and error handling. Other changes include minor docstring edits, code cleanup, and import organization.

**VDC Storage Profile Enhancements:**

* Added the `UpdateStorageProfile` command to `storage_profile_commands.go`, allowing updates to storage profile limits and default status for a VDC, with validation to ensure only one default profile and that new limits are not below current usage.
* Improved documentation and comments for storage profile deletion and update logic.

**General API Client Cleanups:**

* Removed unnecessary blank lines and docstring comments between API client methods in several files (`zz_edgegateway.go`, `zz_publicip.go`, `zz_services.go`, `zz_t0.go`, `zz_bandwidth.go`, and `zz_organization.go`) for better code organization. [[1]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL26) [[2]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL35) [[3]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL44-L50) [[4]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cR55) [[5]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L26) [[6]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L35) [[7]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L44-R47) [[8]](diffhunk://#diff-12dd6e4196fe7e538ab746b80f80856b8b1837dc71528eda38c86f6e68c94420L26) [[9]](diffhunk://#diff-12dd6e4196fe7e538ab746b80f80856b8b1837dc71528eda38c86f6e68c94420L35-R44) [[10]](diffhunk://#diff-6a9903a40d84c6e316f9faa105c3da47e467cfd3c8f0579da798657f4fb793e9L26) [[11]](diffhunk://#diff-6a9903a40d84c6e316f9faa105c3da47e467cfd3c8f0579da798657f4fb793e9R34) [[12]](diffhunk://#diff-4fe60b7d03ee0aed90edef231c13e1d8697977143158d7f06e77f4a47055de60L26) [[13]](diffhunk://#diff-4fe60b7d03ee0aed90edef231c13e1d8697977143158d7f06e77f4a47055de60R34) [[14]](diffhunk://#diff-40694675b13474d9e91e2d613d3cab7686d6d331b2bc533c81342f0162cadc7aR26)

**Testing and Imports:**

* Cleaned up and reordered imports in `storage_profile_test.go` for consistency and clarity.

**Miscellaneous:**

* Added a `//nolint:gocyclo` directive to the `init` function in `storage_profile_commands.go` to suppress cyclomatic complexity warnings.This pull request introduces a new feature for updating VDC storage profiles, along with associated tests and some minor improvements and cleanups. The main change is the addition of the `UpdateStorageProfile` command, which allows users to update the limit and default status of storage profiles within a VDC. The update logic includes validation to ensure that only valid changes are made (e.g., the limit cannot be set below the used space, and only one profile can be set as default). Comprehensive tests have been added to cover various success and error scenarios. Minor improvements include a documentation fix and a linter suppression.

**New Feature: Update VDC Storage Profiles**
- Added the `UpdateStorageProfile` command to `storage_profile_commands.go`, enabling updates to storage profile limits and default status within a VDC. Includes validation to ensure only one profile is set as default and that limits are not set below the used space.
- Added a comprehensive test suite for the new `UpdateStorageProfile` command in `storage_profile_test.go`, covering success cases and a wide range of error scenarios.

**Improvements and Cleanups**
- Added `//nolint:gocyclo` to suppress linter warnings for cyclomatic complexity in the `init` function of `storage_profile_commands.go`.
- Fixed a comment typo in `storage_profile_commands.go` (changed "treated" to "processed").
- Reordered imports in `storage_profile_test.go` for consistency.

**Minor Cleanups in API EdgeGateway and Organization**
- Removed extra blank lines in several auto-generated API files for consistency (`zz_edgegateway.go`, `zz_publicip.go`, `zz_services.go`, `zz_t0.go`, `zz_bandwidth.go`, `zz_organization.go`). [[1]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL26) [[2]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL35) [[3]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cL44-L50) [[4]](diffhunk://#diff-e20b1ecef6ff224b09a73e7d52b1a1597cad6c6c7bd6d0110de9310315f48b8cR55) [[5]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L26) [[6]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L35) [[7]](diffhunk://#diff-5d94e9ce9593945073106a4e992e70db4623a9ebf5b148dda631c1bcfbe22ab5L44-R47) [[8]](diffhunk://#diff-12dd6e4196fe7e538ab746b80f80856b8b1837dc71528eda38c86f6e68c94420L26) [[9]](diffhunk://#diff-12dd6e4196fe7e538ab746b80f80856b8b1837dc71528eda38c86f6e68c94420L35-R44) [[10]](diffhunk://#diff-6a9903a40d84c6e316f9faa105c3da47e467cfd3c8f0579da798657f4fb793e9L26) [[11]](diffhunk://#diff-6a9903a40d84c6e316f9faa105c3da47e467cfd3c8f0579da798657f4fb793e9R34) [[12]](diffhunk://#diff-4fe60b7d03ee0aed90edef231c13e1d8697977143158d7f06e77f4a47055de60L26) [[13]](diffhunk://#diff-4fe60b7d03ee0aed90edef231c13e1d8697977143158d7f06e77f4a47055de60R34) [[14]](diffhunk://#diff-40694675b13474d9e91e2d613d3cab7686d6d331b2bc533c81342f0162cadc7aR26)

These changes significantly enhance the SDK's capabilities for managing VDC storage profiles and improve code quality and maintainability.