### PR TITLE
chore: improve linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,8 +26,6 @@ linters:
     - errname # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`. [fast: false, auto-fix: false]
     - errorlint # Linter for error strings [fast: false, auto-fix: false]
     - forbidigo # Forbids identifiers [fast: true, auto-fix: false]
-    - goconst # Finds repeated strings [fast: true, auto-fix: false]
-    - gocyclo # Computes and checks the cyclomatic complexity of functions [fast: true, auto-fix: false]
     - goheader # Checks is file header matches to pattern [fast: true, auto-fix: false]
     - gomoddirectives # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. [fast: true, auto-fix: false]
     - gomodguard # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. [fast: true, auto-fix: false]
@@ -47,7 +45,6 @@ linters:
     - rowserrcheck # checks whether Err of rows is checked successfully [fast: false, auto-fix: false]
     - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed. [fast: false, auto-fix: false]
     - staticcheck # Staticcheck is `go vet` on steroids [fast: false, auto-fix: false]
-    - tagliatelle # Checks for the presence of struct tags [fast: false, auto-fix: false]
     - tparallel # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes [fast: false, auto-fix: false]
     - unconvert # Remove unnecessary type conversions [fast: false, auto-fix: false]
     - unparam # Finds function parameters that are not used [fast: false, auto-fix: false]
@@ -97,10 +94,6 @@ linters:
           # Default: ""
           rules: '${base-path}/ruleguard/rules_*.go'
   
-    # custom:
-    #   linter-sdkv2:
-    #     type: "module"
-    #     description: This linter enforces conventions in the CloudAvenue SDK v2.
     gosec:
       excludes:
         - G115  # Potential integer overflow when converting between integer types
@@ -114,61 +107,6 @@ linters:
           severity: warning
           disabled: false
         - name: indent-error-flow
-          severity: warning
-          disabled: false
-        - name: var-naming
-          arguments:
-            - []
-            - - ACL
-              - API
-              - ASCII
-              - CPU
-              - CSS
-              - DNS
-              - EOF
-              - GUID
-              - HTML
-              - HTTP
-              - HTTPS
-              - ID
-              - IP
-              - JSON
-              - LHS
-              - QPS
-              - RAM
-              - RHS
-              - RPC
-              - SLA
-              - SMTP
-              - SQL
-              - SSH
-              - TCP
-              - TLS
-              - TTL
-              - UDP
-              - UI
-              - UID
-              - UUID
-              - URI
-              - URL
-              - UTF8
-              - VM
-              - XML
-              - XMPP
-              - XSRF
-              - XSS
-              - SSL
-              - VDC
-              - DFW
-              - VLAN
-              - IAM
-              - VCDA
-              - NAT
-              - VPN
-              - BMS
-              - SAML
-              - VDCG
-            - - skip-package-name-checks: true
           severity: warning
           disabled: false
   exclusions:

--- a/api/draas/v1/draas_commands.go
+++ b/api/draas/v1/draas_commands.go
@@ -17,6 +17,5 @@ func init() {
 	// * Draas
 	cmds.Register(commands.Command{
 		Namespace: "Draas",
-		Verb:      "",
 	})
 }

--- a/api/edgegateway/v1/services_commands.go
+++ b/api/edgegateway/v1/services_commands.go
@@ -186,8 +186,6 @@ func init() {
 			},
 		},
 
-		ModelType: nil, // No model type is returned for this command.
-
 		RunnerFunc: func(ctx context.Context, cmd *commands.Command, client, params any) (any, error) {
 			cc := client.(*Client)
 			p := params.(types.ParamsEdgeGateway)
@@ -257,7 +255,6 @@ func init() {
 				},
 			},
 		},
-		ModelType: nil, // No model type is returned for this command.
 		RunnerFunc: func(ctx context.Context, cmd *commands.Command, client, params any) (any, error) {
 			cc := client.(*Client)
 			p := params.(types.ParamsEdgeGateway)

--- a/api/vdc/v1/vdc_commands.go
+++ b/api/vdc/v1/vdc_commands.go
@@ -575,13 +575,6 @@ func init() { //nolint:gocyclo
 	})
 }
 
-func vcpuToMhz(vcpu, frequency int) int {
-	if vcpu <= 0 || frequency <= 0 {
-		return 0
-	}
-	return vcpu * frequency
-}
-
 func serviceClassToCPUInMhz(serviceClass string) int {
 	switch serviceClass {
 	case "VOIP":

--- a/api/vdcgroup/v1/vdcgroup_commands.go
+++ b/api/vdcgroup/v1/vdcgroup_commands.go
@@ -103,7 +103,7 @@ func init() {
 				Validators: []commands.Validator{
 					commands.ValidatorRequiredIfParamIsNull("name"),
 					commands.ValidatorOmitempty(),
-					commands.ValidatorURN("vdcGroup"),
+					commands.ValidatorURN("VDCGroup"),
 				},
 			},
 			commands.ParamsSpec{

--- a/cav/auth_cloudavenue_credential.go
+++ b/cav/auth_cloudavenue_credential.go
@@ -65,7 +65,7 @@ func newCloudavenueCredential(c consoles.ConsoleName, organization, username, pa
 		return nil, err
 	}
 
-	if ok := consoles.CheckOrganizationName(organization); !ok {
+	if ok := consoles.IsValidOrganizationName(organization); !ok {
 		cc.logger.Error("Invalid organization name", "organization", organization)
 		return nil, errors.New("invalid organization name")
 	}

--- a/cav/client_mock_test.go
+++ b/cav/client_mock_test.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
-	"strings"
 
 	"github.com/go-chi/chi/v5"
 
@@ -24,14 +23,6 @@ import (
 const (
 	mockOrg = "cav01ev01ocb0001234"
 )
-
-var pathPrefix = map[subClientName]string{
-	ClientVmware:         "",
-	ClientCerberus:       "",
-	ClientNetbackup:      "/netbackup",
-	subClientName("ihm"): "/ihm",
-	subClientName("s3"):  "/s3",
-}
 
 func newMockClient() (Client, error) {
 	// Mock implementation for testing purposes
@@ -114,13 +105,6 @@ func newMockClient() (Client, error) {
 	}
 
 	return nC, nil
-}
-
-func buildPath(subClient subClientName, path string) string {
-	if !strings.HasPrefix(path, pathPrefix[subClient]) {
-		return pathPrefix[subClient] + path
-	}
-	return path
 }
 
 // * Not used for the moment, but can be used to set mock responses for endpoints.

--- a/commands/params_path.go
+++ b/commands/params_path.go
@@ -54,7 +54,9 @@ func GetValueAtPath(params interface{}, path string) (interface{}, error) {
 				return nil, fmt.Errorf("nil pointer at '%s'", strings.Join(parts[:i], "."))
 			}
 			val = val.Elem()
-			i-- // retry this part with dereferenced value
+			// ! Waiting for validation that it works without it
+			// retry this part with dereferenced value
+			// i-- //nolint:ineffassign
 			continue
 		case reflect.Slice, reflect.Array:
 			index, err := strconv.Atoi(part)
@@ -128,7 +130,9 @@ func StoreValueAtPath(params interface{}, path, value string) error {
 				return fmt.Errorf("nil pointer at '%s'", strings.Join(parts[:i], "."))
 			}
 			val = val.Elem()
-			i-- // retry this part with dereferenced value
+			// ! Waiting for validation that it works without it
+			// retry this part with dereferenced value
+			// i-- //nolint:ineffassign
 			continue
 		case reflect.Slice, reflect.Array:
 			index, err := strconv.Atoi(part)

--- a/commands/params_rules_validation.go
+++ b/commands/params_rules_validation.go
@@ -157,16 +157,6 @@ func toSnakeCase(str string) string {
 	return strings.ToLower(string(out))
 }
 
-func stringToLower(s string) string {
-	res := []rune(s)
-	for i, c := range res {
-		if c >= 'A' && c <= 'Z' {
-			res[i] = c + ('a' - 'A')
-		}
-	}
-	return string(res)
-}
-
 // applyRuleValues applies RuleValues validation logic to fieldVal
 // Now supports RuleValues.Enum values that can be regexp.Regexp or *regexp.Regexp
 func applyRuleValues(fieldVal reflect.Value, rule RuleValues, fieldName string) error {

--- a/commands/reflect.go
+++ b/commands/reflect.go
@@ -12,10 +12,8 @@ package commands
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 
-	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/pkg/errors"
 	"github.com/orange-cloudavenue/common-go/strcase"
 )
 
@@ -80,87 +78,87 @@ func GetParamType(paramType reflect.Type, name string) (reflect.Type, error) {
 
 // getValuesForFieldByName recursively search for fields in a cmdArgs' value and returns its values if they exist.
 // The search is based on the name of the field.
-func getValuesForFieldByName(value reflect.Value, parts []string) (values []reflect.Value, err error) {
-	if len(parts) == 0 {
-		return []reflect.Value{value}, nil
-	}
-	switch value.Kind() {
-	case reflect.Ptr:
-		return getValuesForFieldByName(value.Elem(), parts)
+// func getValuesForFieldByName(value reflect.Value, parts []string) (values []reflect.Value, err error) {
+// 	if len(parts) == 0 {
+// 		return []reflect.Value{value}, nil
+// 	}
+// 	switch value.Kind() {
+// 	case reflect.Ptr:
+// 		return getValuesForFieldByName(value.Elem(), parts)
 
-	case reflect.Slice:
-		values := []reflect.Value(nil)
-		errs := []error(nil)
+// 	case reflect.Slice:
+// 		values := []reflect.Value(nil)
+// 		errs := []error(nil)
 
-		for i := range value.Len() {
-			newValues, err := getValuesForFieldByName(value.Index(i), parts[1:])
-			if err != nil {
-				errs = append(errs, err)
-			} else {
-				values = append(values, newValues...)
-			}
-		}
+// 		for i := range value.Len() {
+// 			newValues, err := getValuesForFieldByName(value.Index(i), parts[1:])
+// 			if err != nil {
+// 				errs = append(errs, err)
+// 			} else {
+// 				values = append(values, newValues...)
+// 			}
+// 		}
 
-		if len(values) == 0 && len(errs) != 0 {
-			return nil, errors.Join(errs...)
-		}
+// 		if len(values) == 0 && len(errs) != 0 {
+// 			return nil, errors.Join(errs...)
+// 		}
 
-		return values, nil
+// 		return values, nil
 
-	case reflect.Map:
-		if value.IsNil() {
-			return nil, nil
-		}
+// 	case reflect.Map:
+// 		if value.IsNil() {
+// 			return nil, nil
+// 		}
 
-		values := []reflect.Value(nil)
+// 		values := []reflect.Value(nil)
 
-		mapKeys := value.MapKeys()
-		sort.Slice(mapKeys, func(i, j int) bool {
-			return mapKeys[i].String() < mapKeys[j].String()
-		})
+// 		mapKeys := value.MapKeys()
+// 		sort.Slice(mapKeys, func(i, j int) bool {
+// 			return mapKeys[i].String() < mapKeys[j].String()
+// 		})
 
-		for _, mapKey := range mapKeys {
-			mapValue := value.MapIndex(mapKey)
-			newValues, err := getValuesForFieldByName(mapValue, parts[1:])
-			if err != nil {
-				return nil, err
-			}
-			values = append(values, newValues...)
-		}
+// 		for _, mapKey := range mapKeys {
+// 			mapValue := value.MapIndex(mapKey)
+// 			newValues, err := getValuesForFieldByName(mapValue, parts[1:])
+// 			if err != nil {
+// 				return nil, err
+// 			}
+// 			values = append(values, newValues...)
+// 		}
 
-		return values, nil
+// 		return values, nil
 
-	case reflect.Struct:
-		anonymousFieldIndexes := []int(nil)
-		fieldIndexByName := map[string]int{}
+// 	case reflect.Struct:
+// 		anonymousFieldIndexes := []int(nil)
+// 		fieldIndexByName := map[string]int{}
 
-		for i := range value.NumField() {
-			field := value.Type().Field(i)
-			if field.Anonymous {
-				anonymousFieldIndexes = append(anonymousFieldIndexes, i)
-			} else {
-				fieldIndexByName[field.Name] = i
-			}
-		}
+// 		for i := range value.NumField() {
+// 			field := value.Type().Field(i)
+// 			if field.Anonymous {
+// 				anonymousFieldIndexes = append(anonymousFieldIndexes, i)
+// 			} else {
+// 				fieldIndexByName[field.Name] = i
+// 			}
+// 		}
 
-		fieldName := strcase.ToPublicGoName(parts[0])
-		if fieldIndex, exist := fieldIndexByName[fieldName]; exist {
-			return getValuesForFieldByName(value.Field(fieldIndex), parts[1:])
-		}
+// 		fieldName := strcase.ToPublicGoName(parts[0])
+// 		if fieldIndex, exist := fieldIndexByName[fieldName]; exist {
+// 			return getValuesForFieldByName(value.Field(fieldIndex), parts[1:])
+// 		}
 
-		// If it does not exist we try to find it in nested anonymous field
-		for _, fieldIndex := range anonymousFieldIndexes {
-			newValues, err := getValuesForFieldByName(value.Field(fieldIndex), parts)
-			if err == nil {
-				return newValues, nil
-			}
-		}
+// 		// If it does not exist we try to find it in nested anonymous field
+// 		for _, fieldIndex := range anonymousFieldIndexes {
+// 			newValues, err := getValuesForFieldByName(value.Field(fieldIndex), parts)
+// 			if err == nil {
+// 				return newValues, nil
+// 			}
+// 		}
 
-		return nil, fmt.Errorf("field %v does not exist for %v", fieldName, value.Type().Name())
-	}
+// 		return nil, fmt.Errorf("field %v does not exist for %v", fieldName, value.Type().Name())
+// 	}
 
-	return nil, errors.New("case is not handled")
-}
+// 	return nil, errors.New("case is not handled")
+// }
 
 type DocModel struct {
 	Object        string `json:"object"`

--- a/internal/itypes/vdc_storage_profile.go
+++ b/internal/itypes/vdc_storage_profile.go
@@ -25,12 +25,12 @@ type (
 		IsDefaultStorageProfile bool   `json:"isDefaultStorageProfile" fake:"true"`
 
 		// Values are in MB
-		Limit int `json:"storageLimitMB" fake:"{number:100000,81920000}"` //nolint:tagliatelle
-		Used  int `json:"storageUsedMB" fake:"{number:1000,100000}"`      //nolint:tagliatelle
+		Limit int `json:"storageLimitMB" fake:"{number:100000,81920000}"`
+		Used  int `json:"storageUsedMB" fake:"{number:1000,100000}"`
 
 		// Vdc information
-		VdcID   string `json:"vdc" fake:"{href_uuid}"` //nolint:revive
-		VdcName string `json:"vdcName" fake:"{word}"`  //nolint:revive
+		VdcID   string `json:"vdc" fake:"{href_uuid}"`
+		VdcName string `json:"vdcName" fake:"{word}"`
 	}
 )
 

--- a/pkg/consoles/consoles.go
+++ b/pkg/consoles/consoles.go
@@ -245,8 +245,8 @@ func FindByOrganizationName(organizationName string) (ConsoleName, bool) {
 	return "", false
 }
 
-// CheckOrganizationName - Returns true if the organization name is valid.
-func CheckOrganizationName(organizationName string) bool {
+// IsValidOrganizationName - Returns true if the organization name is valid.
+func IsValidOrganizationName(organizationName string) bool {
 	if organizationName == "" {
 		return false
 	}

--- a/pkg/consoles/consoles_test.go
+++ b/pkg/consoles/consoles_test.go
@@ -85,9 +85,9 @@ func TestConsoles(t *testing.T) {
 			}
 
 			if !tt.wantErr {
-				got := CheckOrganizationName(tt.orgName)
+				got := IsValidOrganizationName(tt.orgName)
 				if !got {
-					t.Errorf("CheckOrganizationName(%s) = %v, want %v", tt.orgName, got, !tt.wantErr)
+					t.Errorf("IsValidOrganizationName(%s) = %v, want %v", tt.orgName, got, !tt.wantErr)
 					return
 				}
 			}
@@ -260,9 +260,9 @@ func TestCheckOrganizationName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CheckOrganizationName(tt.org)
+			got := IsValidOrganizationName(tt.org)
 			if got != tt.want {
-				t.Errorf("CheckOrganizationName(%q) = %v, want %v", tt.org, got, tt.want)
+				t.Errorf("IsValidOrganizationName(%q) = %v, want %v", tt.org, got, tt.want)
 			}
 		})
 	}

--- a/pkg/errors/common.go
+++ b/pkg/errors/common.go
@@ -9,7 +9,7 @@
 
 package errors
 
-func parseErrorType[errType any](err error) bool {
+func isErrorType[errType any](err error) bool {
 	if err == nil {
 		return false
 	}
@@ -19,9 +19,9 @@ func parseErrorType[errType any](err error) bool {
 }
 
 func IsAPIError(err error) bool {
-	return parseErrorType[*APIError](err)
+	return isErrorType[*APIError](err)
 }
 
 func IsClientError(err error) bool {
-	return parseErrorType[*ClientError](err)
+	return isErrorType[*ClientError](err)
 }

--- a/ruleguard/rules_commands.go
+++ b/ruleguard/rules_commands.go
@@ -1,0 +1,149 @@
+//go:build ruleguard
+// +build ruleguard
+
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 Orange
+ * SPDX-License-Identifier: Mozilla Public License 2.0
+ *
+ * This software is distributed under the MPL-2.0 license.
+ * the text of which is available at https://www.mozilla.org/en-US/MPL/2.0/
+ * or see the "LICENSE" file for more details.
+ */
+
+package gorules
+
+import (
+	"github.com/quasilyte/go-ruleguard/dsl"
+)
+
+// **Details of names of exported functions in `api/` directories :**
+
+// - `List` functions should return a list of objects. No error returned if the list is empty.
+// - `Get` functions should return a single object. Return an error if not found.
+// - `Create` functions create a new object and return it.
+// - `Update` functions update the specified object and return it.
+// - `Delete` functions delete the specified object.
+// - `Enable` functions enable the specified object. Only errors are returned.
+// - `Disable` functions disable the specified object. Only errors are returned.
+// - `Add` functions add a new object. Only errors are returned.
+// - `Remove` functions remove the specified object. Only errors are returned.
+func commandsModelTypes(m dsl.Matcher) {
+	// * Require ModelType
+	m.Match(`commands.Command{ $*_, Namespace: $ns, Verb: $verb, $*_ }`).
+		Where(
+			(m["verb"].Text == `"Create"` ||
+				m["verb"].Text == `"Update"` ||
+				m["verb"].Text == `"Get"` ||
+				m["verb"].Text == `"List"`) &&
+				!m["$$"].Text.Matches(`\bModelType\s*:`)).
+		Report(`Command with Verb:$verb must include ModelType`)
+
+	// * For other verbs, ModelType must NOT be present
+	m.Match(`commands.Command{ $*_, Verb: $verb, $*_ }`).
+		Where(
+			(m["verb"].Text == `"Delete"` ||
+				m["verb"].Text == `"Enable"` ||
+				m["verb"].Text == `"Disable"` ||
+				m["verb"].Text == `"Add"` ||
+				m["verb"].Text == `"Remove"`) &&
+				m["$$"].Text.Matches(`\bModelType\s*:`)).
+		Report(`Command with Verb:$verb must NOT include ModelType`)
+}
+
+// ParamsSpecs should have a Name (only lowercase) and a Description
+func commandsParamsSpecs(m dsl.Matcher) {
+
+	// * Name
+	// Ensure the ParamsSpec struct contains a Name field.
+	m.Match(`commands.ParamsSpec{ $*_ }`).
+		Where(!m["$$"].Text.Matches(`\bName\s*:`)).
+		Report(`ParamsSpec.Name is required`)
+		// Ensure the Name field value matches the required format.
+		// The Name must be lowercase, can contain letters a-z, digits, underscores, and optionally {index} or {key} for templating.
+	// https://regex101.com/r/YcXFnJ/1
+	m.Match(`commands.ParamsSpec{ $*_, Name: $name, $*_ }`).
+		Where(!m["name"].Text.Matches(`^"(?:[a-z_][a-z0-9_]*|\{(?:index|key)\})(?:\.(?:[a-z_][a-z0-9_]*|\{(?:index|key)\}))*"$`)).
+		At(m["name"]).
+		Report(`ParamsSpec.Name ($name) must be lowercase and contain only letters a-z`)
+
+	// * Description
+	m.Match(`commands.ParamsSpec{ $*_, Name: $name, $*_ }`).
+		Where(!m["$$"].Text.Matches(`(?m)^[^\n/]*\bDescription\s*:`)).
+		Report(`ParamsSpec.Description is required`)
+
+		// Ensure the Description field is not empty or only whitespace.
+	m.Match(`commands.ParamsSpec{ $*_, Description: $d, $*_ }`).
+		Where(m["d"].Text.Matches(`^"\s*"$`)).
+		At(m["d"]).
+		Report(`ParamsSpec.Description must not be empty`)
+}
+
+// commands.Command.Verb
+func commandsAllowedVerbs(m dsl.Matcher) {
+	// Check if Verb are defined
+	m.Match(`commands.Command{ $*_, Namespace: $ns, RunnerFunc: $runner, $*_ }`).
+		Where(!m["$$"].Text.Matches(`(?m)^[^\n/]*\bVerb\s*:`)).
+		Report(`commands.Command.Verb is required`)
+
+	// Check if Verb is one of the allowed ones
+	m.Match(`commands.Command{ $*_, Verb: $verb, RunnerFunc: $runner, $*_ }`).
+		Where(!m["verb"].Text.Matches(`^(?:"Create"|"Update"|"Get"|"List"|"Delete"|"Enable"|"Disable"|"Add"|"Remove")$`)).
+		At(m["verb"]).
+		Report(`commands.Command.Verb ($verb) must be one of "Create", "Update", "Get", "List", "Delete", "Enable", "Disable", "Add", "Remove"`)
+}
+
+// commands.Command.ShortDocumentation
+func commandsShortDocumentation(m dsl.Matcher) {
+	// Check if ShortDocumentation is defined
+	m.Match(`commands.Command{ $*_, Namespace: $ns, Verb: $verb, $*_ }`).
+		Where(!m["$$"].Text.Matches(`(?m)^[^\n/]*\bShortDocumentation\s*:`)).
+		Report(`commands.Command.ShortDocumentation is required`)
+
+	// Check if ShortDocumentation is not empty
+	m.Match(`commands.Command{ $*_, ShortDocumentation: $doc, $*_ }`).
+		Where(m["doc"].Text.Matches(`^"\s*"$`)).
+		At(m["doc"]).
+		Report(`commands.Command.ShortDocumentation must not be empty`)
+}
+
+// commands.Command.LongDocumentation
+func commandsLongDocumentation(m dsl.Matcher) {
+	// Check if LongDocumentation is defined
+	m.Match(`commands.Command{ $*_, Namespace: $ns, Verb: $verb, $*_ }`).
+		Where(!m["$$"].Text.Matches(`(?m)^[^\n/]*\bLongDocumentation\s*:`)).
+		Report(`commands.Command.LongDocumentation is required`)
+
+	// Check if LongDocumentation is not empty
+	m.Match(`commands.Command{ $*_, LongDocumentation: $doc, $*_ }`).
+		Where(m["doc"].Text.Matches(`^"\s*"$`)).
+		At(m["doc"]).
+		Report(`commands.Command.LongDocumentation must not be empty`)
+}
+
+// commands.Command.Namespace
+func commandsNamespace(m dsl.Matcher) {
+	// Check if Namespace is defined
+	m.Match(`commands.Command{ $*_ }`).
+		Where(!m["$$"].Text.Matches(`(?m)^[^\n/]*\bNamespace\s*:`)).
+		Report(`commands.Command.namespace is required`)
+
+	// Check if Namespace is not empty
+	m.Match(`commands.Command{ $*_, Namespace: $ns, $*_ }`).
+		Where(m["ns"].Text.Matches(`^"\s*"$`)).
+		At(m["ns"]).
+		Report(`commands.Command.Namespace must not be empty`)
+}
+
+// commands.Command.RunnerFunc
+func commandsRunnerFunc(m dsl.Matcher) {
+	// Check if RunnerFunc is defined
+	m.Match(`commands.Command{ $*_, Namespace: $ns, Verb: $verb, $*_ }`).
+		Where(!m["$$"].Text.Matches(`(?m)^[^\n/]*\bRunnerFunc\s*:`)).
+		Report(`commands.Command.RunnerFunc is required`)
+
+	// Check if RunnerFunc is not nil
+	m.Match(`commands.Command{ $*_, RunnerFunc: $rf, $*_ }`).
+		Where(m["rf"].Text == "nil").
+		At(m["rf"]).
+		Report(`commands.Command.RunnerFunc must not be nil`)
+}

--- a/types/organization.go
+++ b/types/organization.go
@@ -46,7 +46,7 @@ type ModelGetOrganization struct {
 
 type ModelGetOrganizationResources struct {
 	// Number of Org VDCs
-	Vdc int `documentation:"Number of VDC(s) in your organization"` //nolint:revive
+	Vdc int `documentation:"Number of VDC(s) in your organization"`
 
 	// Number of Catalog media(s)
 	Catalog int `documentation:"Number of Catalog media(s)"`

--- a/types/vdc_storage_profile.go
+++ b/types/vdc_storage_profile.go
@@ -33,25 +33,25 @@ type (
 	ParamsListStorageProfile struct {
 		ID      string
 		Name    string
-		VdcID   string //nolint:revive
-		VdcName string //nolint:revive
+		VdcID   string
+		VdcName string
 	}
 
 	ParamsAddStorageProfile struct {
-		VdcID           string //nolint:revive
-		VdcName         string //nolint:revive
+		VdcID           string
+		VdcName         string
 		StorageProfiles []ParamsCreateVDCStorageProfile
 	}
 
 	ParamsUpdateStorageProfile struct {
-		VdcID           string //nolint:revive
-		VdcName         string //nolint:revive
+		VdcID           string
+		VdcName         string
 		StorageProfiles []ParamsUpdateVDCStorageProfile
 	}
 
 	ParamsDeleteStorageProfile struct {
-		VdcID           string //nolint:revive
-		VdcName         string //nolint:revive
+		VdcID           string
+		VdcName         string
 		StorageProfiles []ParamsDeleteVDCStorageProfile
 	}
 )


### PR DESCRIPTION
This pull request contains a mix of refactoring, cleanup, and configuration changes across the codebase. The most significant updates include the removal of unused or redundant code, renaming functions for clarity and consistency, and cleaning up linter and test configurations. Below are the most important changes grouped by theme:

**Linter and Configuration Cleanup:**

* Removed several linters from `.golangci.yml`, including `goconst`, `gocyclo`, and `tagliatelle`, and eliminated the custom `var-naming` rule and its arguments, streamlining linting and reducing unnecessary checks. [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L29-L30) [[2]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L50) [[3]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L100-L103) [[4]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L119-L173)
* Removed `//nolint:tagliatelle` and `//nolint:revive` comments from struct tags in `internal/itypes/vdc_storage_profile.go` as the related linters are no longer used.

**Function and Naming Refactoring:**

* Renamed `CheckOrganizationName` to `IsValidOrganizationName` throughout the codebase for improved clarity and consistency, updating all references and related tests. [[1]](diffhunk://#diff-c1975db3234c4040b249de77b059ad6b8e1b54fe442d2c183e54a71952255617L248-R249) [[2]](diffhunk://#diff-15dad32600d1b241ee36ee9476e94a06a8b4b486d65686642eead40cc4868637L68-R68) [[3]](diffhunk://#diff-189bfda1d5ed23dd774a1923e11afd4b7397a65e3ee606e5737b1d6fb5611af6L88-R90) [[4]](diffhunk://#diff-189bfda1d5ed23dd774a1923e11afd4b7397a65e3ee606e5737b1d6fb5611af6L263-R265)
* Renamed the internal function `parseErrorType` to `isErrorType` in `pkg/errors/common.go` and updated its usage in `IsAPIError` and `IsClientError` for clearer intent. [[1]](diffhunk://#diff-6e3aa1090036b6f6aa0bbc7bfa06a76b97a8e24fdc6cbdbcff78e41c67f907fbL12-R12) [[2]](diffhunk://#diff-6e3aa1090036b6f6aa0bbc7bfa06a76b97a8e24fdc6cbdbcff78e41c67f907fbL22-R26)

**Codebase Simplification and Dead Code Removal:**

* Removed unused or redundant functions such as `vcpuToMhz` in `api/vdc/v1/vdc_commands.go` and `stringToLower` in `commands/params_rules_validation.go`, as well as the `buildPath` helper and related test code in `cav/client_mock_test.go`. [[1]](diffhunk://#diff-62004e6d0f111ab3d9dc82efdd16198bfee60a26c3a378897d04d26c75f605adL578-L584) [[2]](diffhunk://#diff-2079b1b8bb253a08f20a7744213d1876fa4667b53f0087ec2814adae62a0279cL160-L169) [[3]](diffhunk://#diff-f4ed089cbf74b7c6c160df72f75511868241b04d0da815e2729801dd63e58aacL28-L35) [[4]](diffhunk://#diff-f4ed089cbf74b7c6c160df72f75511868241b04d0da815e2729801dd63e58aacL119-L125)
* Commented out the `getValuesForFieldByName` function in `commands/reflect.go`, indicating it is no longer in use but retained for reference.
* Removed unnecessary imports, such as `sort` and `errors` from `commands/reflect.go` and `"strings"` from `cav/client_mock_test.go`. [[1]](diffhunk://#diff-b7157ac360a5440ad279507a6d95a93faf6833a12f6acd35346f2d9cd0b8744cL15-L18) [[2]](diffhunk://#diff-f4ed089cbf74b7c6c160df72f75511868241b04d0da815e2729801dd63e58aacL15)

**Parameter and Validator Adjustments:**

* Updated a validator in `api/vdcgroup/v1/vdcgroup_commands.go` from `commands.ValidatorURN("vdcGroup")` to `commands.ValidatorURN("VDCGroup")` for consistency.
* Modified pointer dereference logic in `commands/params_path.go` by commenting out a decrement operation, pending validation that the change is safe. [[1]](diffhunk://#diff-13e3161a43b49a43a881fd02b695cc0d7a67fe504419264cdcdd5c8456545edeL57-R59) [[2]](diffhunk://#diff-13e3161a43b49a43a881fd02b695cc0d7a67fe504419264cdcdd5c8456545edeL131-R135)

**Miscellaneous:**

* Removed unused or redundant fields such as `Verb` and `ModelType` from command registration in various `api` files to clean up command definitions. [[1]](diffhunk://#diff-907293fdb36e855f43d699068796ab362929399c7022fd3387af1ba749c04320L20) [[2]](diffhunk://#diff-01efe0be9233280428f1dddd17e7bf68be370efe12cb484fa0673529793152b0L189-L190) [[3]](diffhunk://#diff-01efe0be9233280428f1dddd17e7bf68be370efe12cb484fa0673529793152b0L260)

These changes collectively improve code readability, maintainability, and reduce technical debt across the project.