### PR TITLE
fix: vdcGroup commands

### DIFF
--- a/api/vdcgroup/v1/vdcgroup_test.go
+++ b/api/vdcgroup/v1/vdcgroup_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/internal/itypes"
 	"github.com/orange-cloudavenue/cloudavenue-sdk-go-v2/types"
 	"github.com/orange-cloudavenue/common-go/generator"
+	"github.com/orange-cloudavenue/common-go/utils"
 )
 
 func TestListVdcGroup(t *testing.T) {
@@ -631,7 +632,7 @@ func TestUpdateVdcGroup(t *testing.T) {
 			name: "Update VDC Group",
 			params: types.ParamsUpdateVdcGroup{
 				ID:          generator.MustGenerate("{urn:vdcGroup}"),
-				Description: "My updated VDC Group",
+				Description: utils.ToPTR("My updated VDC Group"),
 			},
 			expectedErr: false,
 		},
@@ -639,7 +640,7 @@ func TestUpdateVdcGroup(t *testing.T) {
 			name: "Update VDC Group with VDCGroup name",
 			params: types.ParamsUpdateVdcGroup{
 				Name:        "my-updated-vdc-group",
-				Description: "My updated VDC Group",
+				Description: utils.ToPTR("My updated VDC Group"),
 			},
 			expectedErr: false,
 		},
@@ -648,7 +649,7 @@ func TestUpdateVdcGroup(t *testing.T) {
 			params: types.ParamsUpdateVdcGroup{
 				ID:          generator.MustGenerate("{urn:vdcGroup}"),
 				Name:        "my-updated-vdc-group",
-				Description: "My updated VDC Group",
+				Description: utils.ToPTR("My updated VDC Group"),
 			},
 			mockResponseStatus: 400,
 			expectedErr:        true,
@@ -658,7 +659,7 @@ func TestUpdateVdcGroup(t *testing.T) {
 			params: types.ParamsUpdateVdcGroup{
 				ID:          generator.MustGenerate("{urn:vdcGroup}"),
 				Name:        "my-updated-vdc-group",
-				Description: "My updated VDC Group",
+				Description: utils.ToPTR("My updated VDC Group"),
 			},
 			mockListVdcGroupResponseStatus: 404,
 			expectedErr:                    true,
@@ -668,7 +669,7 @@ func TestUpdateVdcGroup(t *testing.T) {
 			params: types.ParamsUpdateVdcGroup{
 				ID:          generator.MustGenerate("{urn:vdcGroup}"),
 				Name:        "my-updated-vdc-group",
-				Description: "My updated VDC Group",
+				Description: utils.ToPTR("My updated VDC Group"),
 			},
 			mockListVdcGroupResponse:       itypes.ApiResponseListVdcGroup{Values: []itypes.ApiResponseListVdcGroupDetails{}},
 			mockListVdcGroupResponseStatus: 200,

--- a/cmd/devref/functionalities.json
+++ b/cmd/devref/functionalities.json
@@ -416,7 +416,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:fa536463-2436-47cf-aa26-62554176c8a7",
+                "example": "urn:vcloud:gateway:18c91792-5370-4344-9f88-2c1d12de7ce5",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -445,7 +445,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:61b8a1bf-28d0-44fe-b25e-3cd180e074bb",
+                "example": "urn:vcloud:gateway:307c91c8-19c7-4a3d-81f1-d1b1231ddc4c",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -2684,7 +2684,7 @@
         "resource": "",
         "verb": "Get",
         "short_documentation": "Get a Vdc Group",
-        "long_documentation": "Retrieve detailed information about a specific Vdc Group.",
+        "long_documentation": "Retrieve detailed information about a specific Vdc Group by its ID or name. This command returns all attributes and configuration details of the selected Vdc Group, helping you understand its current state and associated resources.",
         "markdown_documentation": "",
         "params": [
           {
@@ -2804,7 +2804,7 @@
         "resource": "",
         "verb": "Update",
         "short_documentation": "Update a Vdc Group",
-        "long_documentation": "Update an existing Virtual Data Center Group (Vdc Group) in your organization.",
+        "long_documentation": "Update an existing Virtual Data Center Group (Vdc Group) in your organization. You can modify attributes such as the name, description, and associated Vdcs. To add or remove Vdcs, use the dedicated commands. If you want to modify the Vdcs associated with the Vdc Group, refer all the Vdcs you want to have associated with the Vdc Group in the `vdcs` parameter. Vdcs not present in this list will be removed from the Vdc Group.",
         "markdown_documentation": "",
         "params": [
           {
@@ -2830,6 +2830,22 @@
             "example": "",
             "type": "string",
             "validators_description": ""
+          },
+          {
+            "name": "vdcs.{index}.id",
+            "description": "ID of the Vdc to add",
+            "required": true,
+            "example": "",
+            "type": "string",
+            "validators_description": "The value is required if the parameter `vdcs.{index}.name` is null., Validates that the value is a valid URN (`vdc`).. \n"
+          },
+          {
+            "name": "vdcs.{index}.name",
+            "description": "Name of the Vdc to add",
+            "required": true,
+            "example": "",
+            "type": "string",
+            "validators_description": "The value is required if the parameter `vdcs.{index}.id` is null., "
           }
         ],
         "deprecated": false,

--- a/types/vdcgroup.go
+++ b/types/vdcgroup.go
@@ -75,7 +75,10 @@ type (
 		Name string
 
 		// Description is the new description of the Vdc Group.
-		Description string
+		Description *string
+
+		// Vdcs is the list of Vdcs to associate with the Vdc Group.
+		Vdcs []ParamsCreateVdcGroupVdc
 	}
 
 	ParamsDeleteVdcGroup struct {


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Vdc Group API, focusing on enhanced parameter handling, clearer documentation, and code simplification for Vdc Group update, add, and remove operations. The most significant changes are the introduction of new parameters for managing Vdcs within a group, updates to the internal data model, and refactoring of the update/add/remove logic to use shared helper methods and more robust handling of optional fields.

**API Improvements and Documentation:**

* Expanded and clarified the long documentation for both the "Get" and "Update" Vdc Group commands to better explain their behavior and usage, including how Vdc associations are managed. [[1]](diffhunk://#diff-0ceacf65995a9dd404581a1df94a0f4cceae0e1c3ab6dae35a2ee80c79026523L95-R96) [[2]](diffhunk://#diff-0ceacf65995a9dd404581a1df94a0f4cceae0e1c3ab6dae35a2ee80c79026523L288-R289) [[3]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L2687-R2687) [[4]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L2807-R2807)
* Added new parameters `vdcs.{index}.id` and `vdcs.{index}.name` for specifying Vdcs to add to a Vdc Group, with appropriate validation rules and documentation. [[1]](diffhunk://#diff-0ceacf65995a9dd404581a1df94a0f4cceae0e1c3ab6dae35a2ee80c79026523R318-R336) [[2]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44R2833-R2848)

**Parameter and Data Model Changes:**

* Changed the `Description` field in `ParamsUpdateVdcGroup` from a string to a pointer to allow distinguishing between "no update" and "clear value"; added a `Vdcs` slice to support bulk association of Vdcs during updates.

**Command Logic Refactoring:**

* Refactored the update, add, and remove Vdc from Vdc Group logic to use helper methods (`GetVdcGroup`, `UpdateVdcGroup`), reducing code duplication and improving error handling. The update logic now conditionally fetches Vdc IDs by name if not provided, and ensures all Vdc associations are explicitly managed. [[1]](diffhunk://#diff-0ceacf65995a9dd404581a1df94a0f4cceae0e1c3ab6dae35a2ee80c79026523R361) [[2]](diffhunk://#diff-0ceacf65995a9dd404581a1df94a0f4cceae0e1c3ab6dae35a2ee80c79026523L349-R432) [[3]](diffhunk://#diff-0ceacf65995a9dd404581a1df94a0f4cceae0e1c3ab6dae35a2ee80c79026523L497-R603) [[4]](diffhunk://#diff-0ceacf65995a9dd404581a1df94a0f4cceae0e1c3ab6dae35a2ee80c79026523L649-R703)

**Testing Adjustments:**

* Updated tests to use pointer values for `Description` to match the new data model and ensure correct handling of optional fields. [[1]](diffhunk://#diff-115eebfb10a81d5a95aa35d1572b653010c3190cb71bbab070bf4a2f90fafb4fL634-R643) [[2]](diffhunk://#diff-115eebfb10a81d5a95aa35d1572b653010c3190cb71bbab070bf4a2f90fafb4fL651-R652) [[3]](diffhunk://#diff-115eebfb10a81d5a95aa35d1572b653010c3190cb71bbab070bf4a2f90fafb4fL661-R662) [[4]](diffhunk://#diff-115eebfb10a81d5a95aa35d1572b653010c3190cb71bbab070bf4a2f90fafb4fL671-R672)
* Added import of `utils` for pointer helper functions in tests.

**Miscellaneous:**

* Updated example URNs in documentation for clarity. [[1]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L419-R419) [[2]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L448-R448)

These changes collectively make the Vdc Group API more robust, flexible, and easier to use and maintain.