### PR TITLE
fix: vdcgroup root commands definition

### DIFF
--- a/api/vdcgroup/v1/vdcgroup_commands.go
+++ b/api/vdcgroup/v1/vdcgroup_commands.go
@@ -512,6 +512,13 @@ func init() {
 		AutoGenerate: true,
 	})
 
+	// * VdcGroup - VDC
+	cmds.Register(commands.Command{
+		Namespace: "VdcGroup",
+		Resource:  "Vdc",
+		Verb:      "",
+	})
+
 	// * AddVdcToVdcGroup
 	cmds.Register(commands.Command{
 		Namespace:                  "VdcGroup",

--- a/cmd/devref/functionalities.json
+++ b/cmd/devref/functionalities.json
@@ -416,7 +416,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:946de874-d557-442d-8787-e94f813b3b39",
+                "example": "urn:vcloud:gateway:e79dd040-b990-4089-8405-06564a3f5c6b",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -445,7 +445,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:3db9de81-f36d-44d4-ba40-a3a446707f98",
+                "example": "urn:vcloud:gateway:7bef82ff-965b-4158-83b0-5b4e292fba8a",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -2884,6 +2884,105 @@
         ]
       }
     },
-    "SubFunctionality": {}
+    "SubFunctionality": {
+      "Vdc": {
+        "Title": "Vdc",
+        "Documentation": "",
+        "MarkdownDocumentation": "",
+        "Commands": {
+          "Add": {
+            "namespace": "VdcGroup",
+            "resource": "Vdc",
+            "verb": "Add",
+            "short_documentation": "Add a Vdc to a Vdc Group",
+            "long_documentation": "Add an existing Virtual Data Center (Vdc) to a Virtual Data Center Group (Vdc Group) in your organization.",
+            "markdown_documentation": "",
+            "params": [
+              {
+                "name": "id",
+                "description": "ID of the Vdc Group",
+                "required": false,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`vdcGroup`).. \n"
+              },
+              {
+                "name": "name",
+                "description": "Name of the Vdc Group",
+                "required": false,
+                "example": "my-vdc-group",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `id` is null., "
+              },
+              {
+                "name": "vdcs.{index}.id",
+                "description": "ID of the Vdc to add",
+                "required": true,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `vdcs.{index}.name` is null., Validates that the value is a valid URN (`vdc`).. \n"
+              },
+              {
+                "name": "vdcs.{index}.name",
+                "description": "Name of the Vdc to add",
+                "required": true,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `vdcs.{index}.id` is null., "
+              }
+            ],
+            "deprecated": false,
+            "deprecated_message": "",
+            "model": null
+          },
+          "Remove": {
+            "namespace": "VdcGroup",
+            "resource": "Vdc",
+            "verb": "Remove",
+            "short_documentation": "Remove one or more Vdc from a Vdc Group",
+            "long_documentation": "Remove one or more Vdc from a Vdc Group. This action will disassociate the specified Vdc(s) from the Vdc Group.",
+            "markdown_documentation": "",
+            "params": [
+              {
+                "name": "id",
+                "description": "ID of the VDC Group",
+                "required": true,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`vdcGroup`).. \n"
+              },
+              {
+                "name": "name",
+                "description": "Name of the VDC Group",
+                "required": true,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `id` is null., "
+              },
+              {
+                "name": "vdcs.{index}.id",
+                "description": "ID of the Vdc to remove",
+                "required": true,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `vdcs.{index}.name` is null., Validates that the value is a valid URN (`vdc`).. \n"
+              },
+              {
+                "name": "vdcs.{index}.name",
+                "description": "Name of the Vdc to remove",
+                "required": true,
+                "example": "",
+                "type": "string",
+                "validators_description": "The value is required if the parameter `vdcs.{index}.id` is null., "
+              }
+            ],
+            "deprecated": false,
+            "deprecated_message": "",
+            "model": null
+          }
+        },
+        "SubFunctionality": {}
+      }
+    }
   }
 }


### PR DESCRIPTION
This pull request introduces new support for managing Virtual Data Centers (Vdcs) within Vdc Groups, specifically adding the ability to add or remove Vdcs from a Vdc Group. It also updates example URNs for edge gateways in the documentation. The most significant changes are grouped below:

### Vdc Group - Vdc Management

* Added a new `Vdc` sub-functionality under `VdcGroup` in `functionalities.json`, including two new commands:
  - `Add`: Allows adding a Vdc to a Vdc Group.
  - `Remove`: Allows removing one or more Vdcs from a Vdc Group.  
  Both commands include detailed parameter definitions and documentation.
* Registered the new `VdcGroup` - `Vdc` resource in the command registry, enabling the CLI to recognize and handle these new operations.
