### PR TITLE
refactor: update edge gateway public IP parameters and documentation

### DIFF
--- a/api/edgegateway/v1/publicip_test.go
+++ b/api/edgegateway/v1/publicip_test.go
@@ -75,8 +75,8 @@ func TestListEdgegatewayPublicIP(t *testing.T) {
 			}
 			assert.NoError(t, err, "Unexpected error: %v", err)
 			assert.NotNil(t, resp, "Response should not be nil")
-			assert.NotEmpty(t, resp.PublicIPs, "Public IPs should not be empty")
-			for _, ip := range resp.PublicIPs {
+			assert.NotEmpty(t, resp.PublicIps, "Public IPs should not be empty")
+			for _, ip := range resp.PublicIps {
 				assert.NotEmpty(t, ip.ID, "Public IP ID should not be empty")
 				assert.NotEmpty(t, ip.IP, "Public IP Address should not be empty")
 			}
@@ -101,24 +101,24 @@ func TestGetEdgegatewayPublicIP(t *testing.T) {
 		{
 			name: "Valid request",
 			params: types.ParamsGetEdgeGatewayPublicIP{
-				ID: generator.MustGenerate("{urn:edgegateway}"),
-				IP: generator.MustGenerate("{ipv4address}"),
+				EdgeGatewayID: generator.MustGenerate("{urn:edgegateway}"),
+				IP:            generator.MustGenerate("{ipv4address}"),
 			},
 			expectedErr: false,
 		},
 		{
 			name: "Valid request by name",
 			params: types.ParamsGetEdgeGatewayPublicIP{
-				IP:   generator.MustGenerate("{ipv4address}"),
-				Name: generator.MustGenerate("{resource_name:edgegateway}"),
+				IP:              generator.MustGenerate("{ipv4address}"),
+				EdgeGatewayName: generator.MustGenerate("{resource_name:edgegateway}"),
 			},
 			expectedErr: false,
 		},
 		{
 			name: "Failed request by name",
 			params: types.ParamsGetEdgeGatewayPublicIP{
-				IP:   generator.MustGenerate("{ipv4address}"),
-				Name: generator.MustGenerate("{resource_name:edgegateway}"),
+				IP:              generator.MustGenerate("{ipv4address}"),
+				EdgeGatewayName: generator.MustGenerate("{resource_name:edgegateway}"),
 			},
 			mockListResponseStatus: 404,
 			expectedErr:            true,
@@ -126,16 +126,16 @@ func TestGetEdgegatewayPublicIP(t *testing.T) {
 		{
 			name: "Invalid request",
 			params: types.ParamsGetEdgeGatewayPublicIP{
-				ID:   "invalid-id",
-				Name: "invalid-name",
+				EdgeGatewayID:   "invalid-id",
+				EdgeGatewayName: "invalid-name",
 			},
 			expectedErr: true,
 		},
 		{
 			name: "Error 404 Not Found",
 			params: types.ParamsGetEdgeGatewayPublicIP{
-				ID: generator.MustGenerate("{urn:edgegateway}"),
-				IP: generator.MustGenerate("{ipv4address}"),
+				EdgeGatewayID: generator.MustGenerate("{urn:edgegateway}"),
+				IP:            generator.MustGenerate("{ipv4address}"),
 			},
 			mockResponseStatus: 404,
 			expectedErr:        true,
@@ -143,8 +143,8 @@ func TestGetEdgegatewayPublicIP(t *testing.T) {
 		{
 			name: "Simulate empty response",
 			params: types.ParamsGetEdgeGatewayPublicIP{
-				ID: generator.MustGenerate("{urn:edgegateway}"),
-				IP: generator.MustGenerate("{ipv4address}"),
+				EdgeGatewayID: generator.MustGenerate("{urn:edgegateway}"),
+				IP:            generator.MustGenerate("{ipv4address}"),
 			},
 			mockResponse:       &itypes.ApiResponseNetworkServices{},
 			mockResponseStatus: http.StatusOK,

--- a/cmd/devref/functionalities.json
+++ b/cmd/devref/functionalities.json
@@ -416,7 +416,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:946de874-d557-442d-8787-e94f813b3b39",
+                "example": "urn:vcloud:gateway:f6f857be-a59c-4d9d-a61a-51497c3bc684",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -445,7 +445,7 @@
                 "name": "id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
-                "example": "urn:vcloud:gateway:3db9de81-f36d-44d4-ba40-a3a446707f98",
+                "example": "urn:vcloud:gateway:772bd4b0-4f12-404c-a58e-4f11daa8aa91",
                 "type": "string",
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
@@ -541,11 +541,11 @@
             "resource": "PublicIP",
             "verb": "Create",
             "short_documentation": "Create a new Public IP",
-            "long_documentation": "This command allows you to create a new Public IP on the specified Edge Gateway.",
+            "long_documentation": "This command allows you to create a new Public IP (IPv4) on the specified Edge Gateway.",
             "markdown_documentation": "",
             "params": [
               {
-                "name": "id",
+                "name": "edge_gateway_id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
                 "example": "",
@@ -553,7 +553,7 @@
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
               {
-                "name": "name",
+                "name": "edge_gateway_name",
                 "description": "The name of the edge gateway.",
                 "required": false,
                 "example": "tn01e02ocb0001234spt101",
@@ -565,24 +565,19 @@
             "deprecated_message": "",
             "model": [
               {
-                "object": "edgegateway_id",
-                "type": "string",
-                "documentation": "ID of the edge gateway"
-              },
-              {
-                "object": "edgegateway_name",
-                "type": "string",
-                "documentation": "Name of the edge gateway"
-              },
-              {
                 "object": "id",
                 "type": "string",
                 "documentation": "Unique identifier of the public IP"
               },
               {
-                "object": "name",
+                "object": "edge_gateway_id",
                 "type": "string",
-                "documentation": "Public IP logical name"
+                "documentation": "Unique identifier of the edge gateway"
+              },
+              {
+                "object": "edge_gateway_name",
+                "type": "string",
+                "documentation": "Name of the edge gateway"
               },
               {
                 "object": "ip",
@@ -634,7 +629,7 @@
                 "validators_description": "Validates that the value is a valid IPv4 address. (E.g. 192.168.1.1 or 203.0.113.0). \n"
               },
               {
-                "name": "id",
+                "name": "edge_gateway_id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
                 "example": "",
@@ -642,7 +637,7 @@
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
               {
-                "name": "name",
+                "name": "edge_gateway_name",
                 "description": "The name of the edge gateway.",
                 "required": false,
                 "example": "tn01e02ocb0001234spt101",
@@ -654,24 +649,19 @@
             "deprecated_message": "",
             "model": [
               {
-                "object": "edgegateway_id",
-                "type": "string",
-                "documentation": "ID of the edge gateway"
-              },
-              {
-                "object": "edgegateway_name",
-                "type": "string",
-                "documentation": "Name of the edge gateway"
-              },
-              {
                 "object": "id",
                 "type": "string",
                 "documentation": "Unique identifier of the public IP"
               },
               {
-                "object": "name",
+                "object": "edge_gateway_id",
                 "type": "string",
-                "documentation": "Public IP logical name"
+                "documentation": "Unique identifier of the edge gateway"
+              },
+              {
+                "object": "edge_gateway_name",
+                "type": "string",
+                "documentation": "Name of the edge gateway"
               },
               {
                 "object": "ip",
@@ -694,7 +684,7 @@
             "markdown_documentation": "",
             "params": [
               {
-                "name": "id",
+                "name": "edge_gateway_id",
                 "description": "The unique identifier of the edge gateway.",
                 "required": false,
                 "example": "",
@@ -702,7 +692,7 @@
                 "validators_description": "The value is required if the parameter `name` is null., Validates that the value is a valid URN (`edgegateway`).. \n"
               },
               {
-                "name": "name",
+                "name": "edge_gateway_name",
                 "description": "The name of the edge gateway.",
                 "required": false,
                 "example": "tn01e02ocb0001234spt101",
@@ -714,42 +704,27 @@
             "deprecated_message": "",
             "model": [
               {
-                "object": "edgegateway_id",
-                "type": "string",
-                "documentation": "ID of the edge gateway"
-              },
-              {
-                "object": "edgegateway_name",
-                "type": "string",
-                "documentation": "Name of the edge gateway"
-              },
-              {
-                "object": "public_i_ps.{index}.edgegateway_id",
-                "type": "string",
-                "documentation": "ID of the edge gateway"
-              },
-              {
-                "object": "public_i_ps.{index}.edgegateway_name",
-                "type": "string",
-                "documentation": "Name of the edge gateway"
-              },
-              {
-                "object": "public_i_ps.{index}.id",
+                "object": "public_ips.{index}.id",
                 "type": "string",
                 "documentation": "Unique identifier of the public IP"
               },
               {
-                "object": "public_i_ps.{index}.name",
+                "object": "public_ips.{index}.edge_gateway_id",
                 "type": "string",
-                "documentation": "Public IP logical name"
+                "documentation": "Unique identifier of the edge gateway"
               },
               {
-                "object": "public_i_ps.{index}.ip",
+                "object": "public_ips.{index}.edge_gateway_name",
+                "type": "string",
+                "documentation": "Name of the edge gateway"
+              },
+              {
+                "object": "public_ips.{index}.ip",
                 "type": "string",
                 "documentation": "Public IPv4 address"
               },
               {
-                "object": "public_i_ps.{index}.announced",
+                "object": "public_ips.{index}.announced",
                 "type": "bool",
                 "documentation": "True if the public IP is advertised via BGP"
               }

--- a/cmd/devref/go.mod
+++ b/cmd/devref/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/orange-cloudavenue/common-go/generator v1.4.0 // indirect
 	github.com/orange-cloudavenue/common-go/internal/regex v0.0.0-20250812201424-07c3423160b3 // indirect
 	github.com/orange-cloudavenue/common-go/regex v1.2.0 // indirect
-	github.com/orange-cloudavenue/common-go/strcase v1.0.0 // indirect
+	github.com/orange-cloudavenue/common-go/strcase v1.0.1-0.20251003122717-704b635acd44 // indirect
 	github.com/orange-cloudavenue/common-go/urn v1.4.0 // indirect
 	github.com/orange-cloudavenue/common-go/utils v1.0.0 // indirect
 	github.com/orange-cloudavenue/common-go/validators v1.2.0 // indirect

--- a/cmd/devref/go.sum
+++ b/cmd/devref/go.sum
@@ -28,6 +28,8 @@ github.com/orange-cloudavenue/common-go/regex v1.2.0 h1:mJLWYPL1wEllGx9h4YEvsV7Q
 github.com/orange-cloudavenue/common-go/regex v1.2.0/go.mod h1:A7DfA7aAObMJ7DQSBPtVxbr54x0G2WDh4qf40RhZF+0=
 github.com/orange-cloudavenue/common-go/strcase v1.0.0 h1:96+dUHYq91/hiXY/DKO9HGTP3FMsSLikcf/xsp7tqLw=
 github.com/orange-cloudavenue/common-go/strcase v1.0.0/go.mod h1:WGZdlDEE39Yar+OU9pgjMGXMlQWgJrgOOc4q72qNVGE=
+github.com/orange-cloudavenue/common-go/strcase v1.0.1-0.20251003122717-704b635acd44 h1:fb4SHTNHIoSHxfOsYKpGTjx/zcarkY5sJVYwBxpPaX4=
+github.com/orange-cloudavenue/common-go/strcase v1.0.1-0.20251003122717-704b635acd44/go.mod h1:c55s1iokXrqYbtadBTJQvJZpVnFuScxa1B2nM7wdyAM=
 github.com/orange-cloudavenue/common-go/urn v1.4.0 h1:7z0yZuvxoZbebtk0U7WlbDlkBGh5Dj1mDyfxPP1klCA=
 github.com/orange-cloudavenue/common-go/urn v1.4.0/go.mod h1:yXpk5u8KLhpCxmR6uugaKZB/YgsrGg08TZ5XQdybHKs=
 github.com/orange-cloudavenue/common-go/utils v1.0.0 h1:9dUiS72eRXTrOFpomF3IexjfUF5USH9J49w7cUos+rI=

--- a/types/edgegateway_publicip.go
+++ b/types/edgegateway_publicip.go
@@ -11,22 +11,32 @@ package types
 
 type (
 	ModelEdgeGatewayPublicIPs struct {
-		EdgegatewayID   string `documentation:"ID of the edge gateway"`
-		EdgegatewayName string `documentation:"Name of the edge gateway"`
-
-		PublicIPs []ModelEdgeGatewayPublicIP `documentation:"List of public IPs"`
+		PublicIps []ModelEdgeGatewayPublicIP `documentation:"List of public IPs"`
 	}
 
 	ModelEdgeGatewayPublicIP struct {
-		EdgegatewayID   string `documentation:"ID of the edge gateway"`
-		EdgegatewayName string `documentation:"Name of the edge gateway"`
+		ID string `documentation:"Unique identifier of the public IP"`
 
-		ModelEdgeGatewayServicesPublicIP
+		EdgeGatewayID   string `documentation:"Unique identifier of the edge gateway"`
+		EdgeGatewayName string `documentation:"Name of the edge gateway"`
+
+		IP        string `documentation:"Public IPv4 address"`
+		Announced bool   `documentation:"True if the public IP is advertised via BGP"`
+	}
+
+	ParamsListEdgeGatewayPublicIP struct {
+		EdgeGatewayID   string `fake:"{urn:edgegateway}"`
+		EdgeGatewayName string `fake:"{resource_name:edgegateway}"`
+	}
+
+	ParamsCreateEdgeGatewayPublicIP struct {
+		EdgeGatewayID   string `fake:"{urn:edgegateway}"`
+		EdgeGatewayName string `fake:"{resource_name:edgegateway}"`
 	}
 
 	ParamsGetEdgeGatewayPublicIP struct {
-		ID   string `fake:"{urn:edgegateway}"`
-		Name string `fake:"{resource_name:edgegateway}"`
+		EdgeGatewayID   string `fake:"{urn:edgegateway}"`
+		EdgeGatewayName string `fake:"{resource_name:edgegateway}"`
 
 		IP string `validate:"ipv4" fake:"{IPv4Address}"`
 	}


### PR DESCRIPTION
This pull request refactors the parameter and model naming conventions for Edge Gateway Public IP commands and updates related documentation and tests. The main focus is to improve clarity and consistency by replacing generic parameter names like `id` and `name` with more descriptive ones such as `edge_gateway_id` and `edge_gateway_name`. It also updates the structure of returned models to match these changes and clarifies documentation to specify IPv4. No business logic is changed; this is a structural and naming update.

**API and Parameter Naming Consistency:**

* Replaced parameters `id` and `name` with `edge_gateway_id` and `edge_gateway_name` across all relevant commands in `publicip_commands.go` to improve clarity and avoid ambiguity. [[1]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L43-R50) [[2]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L60-R60) [[3]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L73-R80) [[4]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L116-R116) [[5]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L139-R140) [[6]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L157-R160) [[7]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L170-R170) [[8]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L183-R203) [[9]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L231-R234) [[10]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L241-R244) [[11]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L257-R262) [[12]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L269-R300)

* Updated all related struct types and function signatures (e.g., `ParamsCreateEdgeGatewayPublicIP`, `ParamsListEdgeGatewayPublicIP`, `ParamsGetEdgeGatewayPublicIP`) to use the new parameter names. [[1]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L73-R80) [[2]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L183-R203)

**Model and Response Structure Updates:**

* Changed the returned model fields for public IPs to use `EdgeGatewayID`, `EdgeGatewayName`, and other descriptive names, and updated how lists of public IPs are constructed and returned. [[1]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L183-R203) [[2]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L269-R300)

**Documentation and Example Improvements:**

* Updated command documentation to clarify that the created Public IP is IPv4. [[1]](diffhunk://#diff-ed6e33b245ad3e5de6f386dd46a32b785e55dde71a20b0ebb48474cb09646be8L43-R50) [[2]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L544-R556)
* Updated example values and parameter descriptions in `functionalities.json` to match the new naming conventions and provide clearer examples. [[1]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L419-R419) [[2]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L448-R448) [[3]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L544-R556) [[4]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L637-R640) [[5]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L697-R695)

**Test Updates:**

* Refactored tests in `publicip_test.go` to use the new parameter names and updated assertions to match the revised model structure. [[1]](diffhunk://#diff-bee82e510cc6a11abad85b32791ed245c674a13579255a4235e7d8aad37b4f3bL78-R79) [[2]](diffhunk://#diff-bee82e510cc6a11abad85b32791ed245c674a13579255a4235e7d8aad37b4f3bL104-R104) [[3]](diffhunk://#diff-bee82e510cc6a11abad85b32791ed245c674a13579255a4235e7d8aad37b4f3bL113-R137) [[4]](diffhunk://#diff-bee82e510cc6a11abad85b32791ed245c674a13579255a4235e7d8aad37b4f3bL146-R146)

**Model Field Documentation:**

* Updated the model field documentation in `functionalities.json` to match the new field names and clarify the meaning of each field. [[1]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L568-R580) [[2]](diffhunk://#diff-999ea9bb8bbf6bda88c0296ad05849f77dfde3c855e5f068131ab5e60ecd4a44L657-R664)

These changes make the API more self-explanatory and consistent, reducing confusion for users and maintainers.